### PR TITLE
A literal paragraph in a list is not taken as literal

### DIFF
--- a/t/data-30/Lists.asciidoc
+++ b/t/data-30/Lists.asciidoc
@@ -156,3 +156,7 @@ This paragraph belongs to item 1.
 
 2. Item 2 of the outer list.
 
+        y - Vivamus fringilla mi eu lacus
+        n - Vivamus fringilla mi eu lacus
+        q - Vivamus fringilla mi eu lacus
+        ? - Vivamus fringilla mi eu lacus

--- a/t/data-30/Lists.out
+++ b/t/data-30/Lists.out
@@ -154,3 +154,7 @@ This paragraph belongs to item 1.
 
 2. Item 2 of the outer list.
 
+        y - Vivamus fringilla mi eu lacus
+        n - Vivamus fringilla mi eu lacus
+        q - Vivamus fringilla mi eu lacus
+        ? - Vivamus fringilla mi eu lacus

--- a/t/data-30/Lists.po
+++ b/t/data-30/Lists.po
@@ -386,3 +386,13 @@ msgstr ""
 #: ../data-30/Lists.asciidoc:158
 msgid "Item 2 of the outer list."
 msgstr ""
+
+#. type: Plain text
+#: ../data-30/Lists.asciidoc:162
+#, no-wrap
+msgid ""
+"        y - Vivamus fringilla mi eu lacus\n"
+"        n - Vivamus fringilla mi eu lacus\n"
+"        q - Vivamus fringilla mi eu lacus\n"
+"        ? - Vivamus fringilla mi eu lacus\n"
+msgstr ""


### PR DESCRIPTION
With the following change, the po file generated for a literal
paragraph in a list does not appear as literal.

This PR is only to demonstrate the bug I described in #9 