### PR TITLE
Build.PL: add test_requires entry

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -24,6 +24,9 @@ my $build = Po4aBuilder->new
                                                   # translating the
                                                   # po4a's messages.
                     },
+      test_requires => {'SGMLS' => 0,             # Needed for the Sgml module.
+                        'Unicode::GCString' => 0, # Used by the Text module (asciidoc)
+                       },
       script_files => ['po4a-gettextize', 'po4a-updatepo',
           'po4a-translate', 'po4a-normalize', 'po4a', 'scripts/msguntypot',
           'scripts/po4aman-display-po', 'scripts/po4apod-display-po',

--- a/Po4aBuilder.pm
+++ b/Po4aBuilder.pm
@@ -137,6 +137,7 @@ sub ACTION_install {
 #	print ("$k -> ".$self->install_destination($k)."\n");
 #    }
     my $mandir = $self->install_destination('libdoc');
+    $mandir =~ s,/man3$,,;
     $self->install_path(man => $mandir);
 
     my $localedir = $self->install_destination('libdoc');


### PR DESCRIPTION
As for Module::Build  [docs](https://github.com/Perl-Toolchain-Gang/Module-Build/blob/master/lib/Module/Build/API.pod)

> recommends
...
    If a module is recommended but not required, all tests should still pass if the module isn't installed. This may mean that some tests may be skipped if recommended dependencies aren't present.

But as for now the tests for sgml and ascidoc fail if Sgml and GCString are not installed respectively.
So I suggest those modules should also go to test_requires.

