### PR TITLE
po4a.pod: minor fix to description of KernelHelp

### DIFF
--- a/doc/po4a.7.pod
+++ b/doc/po4a.7.pod
@@ -195,9 +195,9 @@ L<Locale::Po4a::Docbook(3pm)> for details.
 =head3 others
 
 Po4a can also handle some more rare or specialized formats, such as the
-documentation of compilation options for the 2.4.x kernels or the diagrams
-produced by the dia tool. Adding a new one is often very easy and the main
-task is to come up with a parser of your target format. See
+documentation of compilation options for the 2.4+ Linux kernels or the
+diagrams produced by the dia tool. Adding a new one is often very easy and
+the main task is to come up with a parser of your target format. See
 L<Locale::Po4a::TransTractor(3pm)> for more information about this.
 
 =head2 Unsupported formats


### PR DESCRIPTION
Current documentation makes think that KernelHelp messages of only exact =2.4.x kernels are handled
and recent versions may not, this commit changes it a bit.