### PR TITLE
bugfix: asciidoc: handle macros with empty target

### DIFF
--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -542,7 +542,7 @@ sub parse {
             }
             @comments=();
         } elsif (not defined $self->{verbatim} and
-                 ($line =~ m/^([\w\d][\w\d-]*)(::)(\S+)\[(.*)\]$/)) {
+                 ($line =~ m/^([\w\d][\w\d-]*)(::)(\S*)\[(.*)\]$/)) {
             my $macroname = $1;
             my $macrotype = $2;
             my $macrotarget = $3;

--- a/t/data-30/StyleMacro.asciidoc
+++ b/t/data-30/StyleMacro.asciidoc
@@ -50,3 +50,6 @@ image::foo.png[title="Image with title but without alt-text"]
 Block image macro without alt text:
 image::foo.png[]
 
+ifeval::[42 == 42]
+// Empty macro target:
+endif::[]

--- a/t/data-30/StyleMacro.out
+++ b/t/data-30/StyleMacro.out
@@ -49,3 +49,5 @@ image::foo.png[title="Image with title but without alt-text"]
 Block image macro without alt text:
 image::foo.png[]
 
+ifeval::[42 == 42]
+endif::[]


### PR DESCRIPTION
Asciidoc macros with an empty target were not matched as being a macro.
An example of a macro with an emtpy target is `endif::[]`

Signed-off-by: Martijn Thé <post@martijnthe.nl>