### PR TITLE
Make Tables a no-wrap output in AsciiDoc

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,7 @@ __   __/ _ \ | ___| ___|
 
 AsciiDoc:
  * Fix Asciidoc unindented lists (GitHub's #149)
+ * Make Asciidoc Tables nowrap and support current format (GitHub's #63)
 
 Translations:
  * Updated: German, thanks Helge Kreutzmann.

--- a/t/03-asciidoc.t
+++ b/t/03-asciidoc.t
@@ -18,9 +18,6 @@ foreach my $AsciiDocTest (@AsciiDocTests) {
     # Tables are currently badly supported.
     # Mark the test as TODO.
     my $todo = "";
-    if ( $AsciiDocTest eq "Tables" ) {
-        $todo = "Tables are currently badly supported.";
-    }
     push @tests,
       {
         'todo'      => $todo,

--- a/t/t-03-asciidoc/Tables.asciidoc
+++ b/t/t-03-asciidoc/Tables.asciidoc
@@ -1,37 +1,78 @@
 Test Tables
 ===========
 
-`---`---
-1   2
-3   4
-5   6
---------
+|===
+|1 | 2
+|3 | 4
+|5 | 6
+|===
 
 
 .An example table
-[grid="all"]
-'---------.--------------
-Column 1   Column 2
--------------------------
-1          Item 1
-2          Item 2
-3          Item 3
--------------------------
-6          Three items
--------------------------
+[grid="all", options="header", cols=">,"]
+|===
+|Column 1 | Column 2
+|1        | Item 1
+|2        | Item 2
+|3        | Item 3
+|6        | Three items
+|===
 
-[frame="all"]
-````~15
-1,2,3,4
-a,b,c,d
-A,B,C,D
-~~~~~~~~
+[frame="all", cols="<,<,<,<", width="15%"]
+|===
+|1|2|3|4
+|a|b|c|d
+|A|B|C|D
+|===
 
-[frame="all", grid="all"]
-.15`20`25`20`~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[frame="all", grid="all", cols="^15,>20,>25,>20", format="csv"]
+|===
 ID,Customer Name,Contact Name,Customer Address,Phone
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 include::customers.csv[]
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+|===
 
+The following examples are drawn from the https://docs.fedoraproject.org/f27/system-administrators-guide/index.html[Fedora System Administrator's Guide]:
 
+[options="header"]
+|===
+|Option|Description
+|[option]`Charset` = __encoding__|Specifies the character set of a generated web page. The _encoding_ has to be a valid character set such as `UTF-8` or `ISO-8859-2`.
+|[option]`Type` = __content-type__|Specifies the media type of a generated web page. The _content-type_ has to be a valid MIME type such as `text/html` or `text/plain`.
+|[option]`DescriptionWidth` = __value__|Specifies the width of the description column. The _value_ can be either a number of characters, or an asterisk (that is, `*`) to adjust the width automatically.
+|[option]`FancyIndexing`|Enables advanced features such as different icons for certain files or possibility to re-sort a directory listing by clicking on a column header.
+|[option]`FolderFirst`|Enables listing directories first, always placing them above files.
+|[option]`HTMLTable`|Enables the use of HTML tables for directory listings.
+|[option]`IconsAreLinks`|Enables using the icons as links.
+|[option]`IconHeight` = __value__|Specifies an icon height. The _value_ is a number of pixels.
+|[option]`IconWidth` = __value__|Specifies an icon width. The _value_ is a number of pixels.
+|[option]`IgnoreCase`|Enables sorting files and directories in a case-sensitive manner.
+|[option]`IgnoreClient`|Disables accepting query variables from a client.
+|[option]`NameWidth` = __value__|Specifies the width of the file name column. The _value_ can be either a number of characters, or an asterisk (that is, `*`) to adjust the width automatically.
+|[option]`ScanHTMLTitles`|Enables parsing the file for a description (that is, the `title` element) in case it is not provided by the [option]`AddDescription` directive.
+|[option]`ShowForbidden`|Enables listing the files with otherwise restricted access.
+|[option]`SuppressColumnSorting`|Disables re-sorting a directory listing by clicking on a column header.
+|[option]`SuppressDescription`|Disables reserving a space for file descriptions.
+|[option]`SuppressHTMLPreamble`|Disables the use of standard HTML preamble when a file specified by the [option]`HeaderName` directive is present.
+|[option]`SuppressIcon`|Disables the use of icons in directory listings.
+|[option]`SuppressLastModified`|Disables displaying the date of the last modification field in directory listings.
+|[option]`SuppressRules`|Disables the use of horizontal lines in directory listings.
+|[option]`SuppressSize`|Disables displaying the file size field in directory listings.
+|[option]`TrackModified`|Enables returning the `Last-Modified` and `ETag` values in the HTTP header.
+|[option]`VersionSort`|Enables sorting files that contain a version number in the expected manner.
+|[option]`XHTML`|Enables the use of XHTML 1.0 instead of the default HTML 3.2.
+|===
+
+Manually wrapped cells
+
+|===
+|Option|Description
+|[option]`Charset` = __encoding__
+|Specifies the character set of a generated web page. The _encoding_ has to be a valid character set such as `UTF-8` or `ISO-8859-2`.
+|[option]`Type` = __content-type__
+|Specifies the media type of a generated web page. The _content-type_
+has to be a valid MIME type such as `text/html` or `text/plain`.
+
+|[option]`DescriptionWidth` = __value__
+
+|Specifies the width of the description column. The _value_ can be either a number of characters, or an asterisk (that is, `*`) to adjust the width automatically.
+|===

--- a/t/t-03-asciidoc/Tables.out
+++ b/t/t-03-asciidoc/Tables.out
@@ -1,37 +1,80 @@
 Test Tables
 ===========
 
-`---`---
-1   2
-3   4
-5   6
---------
+|===
+|1 | 2
+|3 | 4
+|5 | 6
+|===
 
 
 .An example table
-[grid="all"]
-'---------.--------------
-Column 1   Column 2
--------------------------
-1          Item 1
-2          Item 2
-3          Item 3
--------------------------
-6          Three items
--------------------------
+[grid="all", options="header", cols=">,"]
+|===
+|Column 1 | Column 2
+|1        | Item 1
+|2        | Item 2
+|3        | Item 3
+|6        | Three items
+|===
 
-[frame="all"]
-````~15
-1,2,3,4
-a,b,c,d
-A,B,C,D
-~~~~~~~~
+[frame="all", cols="<,<,<,<", width="15%"]
+|===
+|1|2|3|4
+|a|b|c|d
+|A|B|C|D
+|===
 
-[frame="all", grid="all"]
-.15`20`25`20`~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[frame="all", grid="all", cols="^15,>20,>25,>20", format="csv"]
+|===
 ID,Customer Name,Contact Name,Customer Address,Phone
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 include::customers.csv[]
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+|===
 
+The following examples are drawn from the
+https://docs.fedoraproject.org/f27/system-administrators-guide/index.html[Fedora
+System Administrator's Guide]:
 
+[options="header"]
+|===
+|Option|Description
+|[option]`Charset` = __encoding__|Specifies the character set of a generated web page. The _encoding_ has to be a valid character set such as `UTF-8` or `ISO-8859-2`.
+|[option]`Type` = __content-type__|Specifies the media type of a generated web page. The _content-type_ has to be a valid MIME type such as `text/html` or `text/plain`.
+|[option]`DescriptionWidth` = __value__|Specifies the width of the description column. The _value_ can be either a number of characters, or an asterisk (that is, `*`) to adjust the width automatically.
+|[option]`FancyIndexing`|Enables advanced features such as different icons for certain files or possibility to re-sort a directory listing by clicking on a column header.
+|[option]`FolderFirst`|Enables listing directories first, always placing them above files.
+|[option]`HTMLTable`|Enables the use of HTML tables for directory listings.
+|[option]`IconsAreLinks`|Enables using the icons as links.
+|[option]`IconHeight` = __value__|Specifies an icon height. The _value_ is a number of pixels.
+|[option]`IconWidth` = __value__|Specifies an icon width. The _value_ is a number of pixels.
+|[option]`IgnoreCase`|Enables sorting files and directories in a case-sensitive manner.
+|[option]`IgnoreClient`|Disables accepting query variables from a client.
+|[option]`NameWidth` = __value__|Specifies the width of the file name column. The _value_ can be either a number of characters, or an asterisk (that is, `*`) to adjust the width automatically.
+|[option]`ScanHTMLTitles`|Enables parsing the file for a description (that is, the `title` element) in case it is not provided by the [option]`AddDescription` directive.
+|[option]`ShowForbidden`|Enables listing the files with otherwise restricted access.
+|[option]`SuppressColumnSorting`|Disables re-sorting a directory listing by clicking on a column header.
+|[option]`SuppressDescription`|Disables reserving a space for file descriptions.
+|[option]`SuppressHTMLPreamble`|Disables the use of standard HTML preamble when a file specified by the [option]`HeaderName` directive is present.
+|[option]`SuppressIcon`|Disables the use of icons in directory listings.
+|[option]`SuppressLastModified`|Disables displaying the date of the last modification field in directory listings.
+|[option]`SuppressRules`|Disables the use of horizontal lines in directory listings.
+|[option]`SuppressSize`|Disables displaying the file size field in directory listings.
+|[option]`TrackModified`|Enables returning the `Last-Modified` and `ETag` values in the HTTP header.
+|[option]`VersionSort`|Enables sorting files that contain a version number in the expected manner.
+|[option]`XHTML`|Enables the use of XHTML 1.0 instead of the default HTML 3.2.
+|===
+
+Manually wrapped cells
+
+|===
+|Option|Description
+|[option]`Charset` = __encoding__
+|Specifies the character set of a generated web page. The _encoding_ has to be a valid character set such as `UTF-8` or `ISO-8859-2`.
+|[option]`Type` = __content-type__
+|Specifies the media type of a generated web page. The _content-type_
+has to be a valid MIME type such as `text/html` or `text/plain`.
+
+|[option]`DescriptionWidth` = __value__
+
+|Specifies the width of the description column. The _value_ can be either a number of characters, or an asterisk (that is, `*`) to adjust the width automatically.
+|===

--- a/t/t-03-asciidoc/Tables.pot
+++ b/t/t-03-asciidoc/Tables.pot
@@ -7,13 +7,14 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2008-10-12 21:58+0300\n"
-"PO-Revision-Date: 2008-10-12 22:05+0200\n"
+"POT-Creation-Date: 2018-10-03 09:32+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
-"Content-Transfer-Encoding: ENCODING"
+"Content-Transfer-Encoding: 8bit\n"
 
 #. type: Title =
 #: t-03-asciidoc/Tables.asciidoc:2
@@ -21,52 +22,147 @@ msgstr ""
 msgid "Test Tables"
 msgstr ""
 
-# FIXME
-#. type: Plain text
+#. type: Table
 #: t-03-asciidoc/Tables.asciidoc:8
 #, no-wrap
 msgid ""
-"`---`---\n"
-"1   2\n"
-"3   4\n"
-"5   6\n"
+"|===\n"
+"|1 | 2\n"
+"|3 | 4\n"
+"|5 | 6\n"
+"|===\n"
 msgstr ""
 
-# FIXME
-#. type: delimited block -
-#: t-03-asciidoc/Tables.asciidoc:15
+#. type: Block title
+#: t-03-asciidoc/Tables.asciidoc:11
 #, no-wrap
-msgid ""
-".An example table\n"
-"[grid=\"all\"]\n"
-"'---------.--------------\n"
-"Column 1   Column 2\n"
+msgid "An example table"
 msgstr ""
 
-# FIXME
-#. type: Plain text
+#. type: Table
 #: t-03-asciidoc/Tables.asciidoc:19
 #, no-wrap
 msgid ""
-"1          Item 1\n"
-"2          Item 2\n"
-"3          Item 3\n"
+"|===\n"
+"|Column 1 | Column 2\n"
+"|1        | Item 1\n"
+"|2        | Item 2\n"
+"|3        | Item 3\n"
+"|6        | Three items\n"
+"|===\n"
 msgstr ""
 
-# FIXME
-#. type: delimited block -
-#: t-03-asciidoc/Tables.asciidoc:21
+#. type: Table
+#: t-03-asciidoc/Tables.asciidoc:26
 #, no-wrap
-msgid "6          Three items\n"
+msgid ""
+"|===\n"
+"|1|2|3|4\n"
+"|a|b|c|d\n"
+"|A|B|C|D\n"
+"|===\n"
 msgstr ""
 
-# FIXME
-#. type: Plain text
-#: t-03-asciidoc/Tables.asciidoc:28
-msgid "[frame=\"all\"] ````~15 1,2,3,4 a,b,c,d A,B,C,D"
+#. type: Table
+#: t-03-asciidoc/Tables.asciidoc:32
+#, no-wrap
+msgid ""
+"|===\n"
+"ID,Customer Name,Contact Name,Customer Address,Phone\n"
+"include::customers.csv[]\n"
+"|===\n"
 msgstr ""
 
 #. type: Plain text
 #: t-03-asciidoc/Tables.asciidoc:35
-msgid "include::customers.csv[]"
+msgid ""
+"The following examples are drawn from the "
+"https://docs.fedoraproject.org/f27/system-administrators-guide/index.html[Fedora "
+"System Administrator's Guide]:"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/Tables.asciidoc:63
+#, no-wrap
+msgid ""
+"|===\n"
+"|Option|Description\n"
+"|[option]`Charset` = __encoding__|Specifies the character set of a generated "
+"web page. The _encoding_ has to be a valid character set such as `UTF-8` or "
+"`ISO-8859-2`.\n"
+"|[option]`Type` = __content-type__|Specifies the media type of a generated "
+"web page. The _content-type_ has to be a valid MIME type such as `text/html` "
+"or `text/plain`.\n"
+"|[option]`DescriptionWidth` = __value__|Specifies the width of the "
+"description column. The _value_ can be either a number of characters, or an "
+"asterisk (that is, `*`) to adjust the width automatically.\n"
+"|[option]`FancyIndexing`|Enables advanced features such as different icons "
+"for certain files or possibility to re-sort a directory listing by clicking "
+"on a column header.\n"
+"|[option]`FolderFirst`|Enables listing directories first, always placing "
+"them above files.\n"
+"|[option]`HTMLTable`|Enables the use of HTML tables for directory "
+"listings.\n"
+"|[option]`IconsAreLinks`|Enables using the icons as links.\n"
+"|[option]`IconHeight` = __value__|Specifies an icon height. The _value_ is a "
+"number of pixels.\n"
+"|[option]`IconWidth` = __value__|Specifies an icon width. The _value_ is a "
+"number of pixels.\n"
+"|[option]`IgnoreCase`|Enables sorting files and directories in a "
+"case-sensitive manner.\n"
+"|[option]`IgnoreClient`|Disables accepting query variables from a client.\n"
+"|[option]`NameWidth` = __value__|Specifies the width of the file name "
+"column. The _value_ can be either a number of characters, or an asterisk "
+"(that is, `*`) to adjust the width automatically.\n"
+"|[option]`ScanHTMLTitles`|Enables parsing the file for a description (that "
+"is, the `title` element) in case it is not provided by the "
+"[option]`AddDescription` directive.\n"
+"|[option]`ShowForbidden`|Enables listing the files with otherwise restricted "
+"access.\n"
+"|[option]`SuppressColumnSorting`|Disables re-sorting a directory listing by "
+"clicking on a column header.\n"
+"|[option]`SuppressDescription`|Disables reserving a space for file "
+"descriptions.\n"
+"|[option]`SuppressHTMLPreamble`|Disables the use of standard HTML preamble "
+"when a file specified by the [option]`HeaderName` directive is present.\n"
+"|[option]`SuppressIcon`|Disables the use of icons in directory listings.\n"
+"|[option]`SuppressLastModified`|Disables displaying the date of the last "
+"modification field in directory listings.\n"
+"|[option]`SuppressRules`|Disables the use of horizontal lines in directory "
+"listings.\n"
+"|[option]`SuppressSize`|Disables displaying the file size field in directory "
+"listings.\n"
+"|[option]`TrackModified`|Enables returning the `Last-Modified` and `ETag` "
+"values in the HTTP header.\n"
+"|[option]`VersionSort`|Enables sorting files that contain a version number "
+"in the expected manner.\n"
+"|[option]`XHTML`|Enables the use of XHTML 1.0 instead of the default HTML "
+"3.2.\n"
+"|===\n"
+msgstr ""
+
+#. type: Plain text
+#: t-03-asciidoc/Tables.asciidoc:66
+msgid "Manually wrapped cells"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/Tables.asciidoc:78
+#, no-wrap
+msgid ""
+"|===\n"
+"|Option|Description\n"
+"|[option]`Charset` = __encoding__\n"
+"|Specifies the character set of a generated web page. The _encoding_ has to "
+"be a valid character set such as `UTF-8` or `ISO-8859-2`.\n"
+"|[option]`Type` = __content-type__\n"
+"|Specifies the media type of a generated web page. The _content-type_\n"
+"has to be a valid MIME type such as `text/html` or `text/plain`.\n"
+"\n"
+"|[option]`DescriptionWidth` = __value__\n"
+"\n"
+"|Specifies the width of the description column. The _value_ can be either a "
+"number of characters, or an asterisk (that is, `*`) to adjust the width "
+"automatically.\n"
+"|===\n"
 msgstr ""


### PR DESCRIPTION
Table formats have changed.  The old formats are deprecated
and parsed by neither asciidoc or asciidoctor.

Treating tables as no-wrap passes them as preserved

Tentative fix for #61 - do not merge yet