### PR TITLE
yaml: Use ">" instead in references

### DIFF
--- a/lib/Locale/Po4a/Yaml.pm
+++ b/lib/Locale/Po4a/Yaml.pm
@@ -79,7 +79,7 @@ sub walk_yaml {
         print STDERR  "begin a hash\n" if $self->{'options'}{'debug'};
         foreach my $key (sort keys %$el) {
             if (ref $el->{$key} ne ref "") {
-                &walk_yaml($self, $el->{$key}, "$reference:$key");
+                &walk_yaml($self, $el->{$key}, "$reference>$key");
             } else {
                 next if (($self->{options}{keys} ne "") and (!exists $self->{keys}{lc($key)}));
                 my $trans = $self->translate(Encode::encode_utf8($el->{$key}), $reference, "Hash Value - Key: $key", 'wrap' => 0);
@@ -91,7 +91,7 @@ sub walk_yaml {
         print STDERR  "begin an array\n" if $self->{'options'}{'debug'};
         for my $i (0 .. $#{$el}) {
             if (ref $el->[$i] ne ref "") {
-                &walk_yaml($self, $el->[$i], "$reference:");
+                &walk_yaml($self, $el->[$i], "$reference>");
             } else {
                 my $trans = $self->translate(Encode::encode_utf8($el->[$i]), $reference, "Array Element", 'wrap' => 0);
                 $el->[$i] = Encode::decode_utf8($trans); # Save the translation

--- a/t/data-32/yamlkeysoption1.po
+++ b/t/data-32/yamlkeysoption1.po
@@ -22,61 +22,61 @@ msgid "Fedora Installation Guide"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics:
+#: >Topics>
 #, no-wrap
 msgid "Book Information"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics:
+#: >Topics>
 #, no-wrap
 msgid "Preface"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics:
+#: >Topics>
 #, no-wrap
 msgid "Introduction"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics:
+#: >Topics>
 #, no-wrap
 msgid "Downloading Fedora"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics:
+#: >Topics>
 #, no-wrap
 msgid "Installing Fedora"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics::Topics:
+#: >Topics>>Sub-Topics>
 #, no-wrap
 msgid "Preparing for Installation"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics::Topics:
+#: >Topics>>Sub-Topics>
 #, no-wrap
 msgid "Booting the Installation"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics::Topics:
+#: >Topics>>Sub-Topics>
 #, no-wrap
 msgid "Installing Using Anaconda"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics::Topics:
+#: >Topics>>Sub-Topics>
 #, no-wrap
 msgid "After the Installation"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics::Topics:
+#: >Topics>>Sub-Topics>
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""

--- a/t/data-32/yamlkeysoption2.po
+++ b/t/data-32/yamlkeysoption2.po
@@ -22,97 +22,97 @@ msgid "Fedora Installation Guide"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Topics:
+#: >Topics>
 #, no-wrap
 msgid "index"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics:
+#: >Topics>
 #, no-wrap
 msgid "Book Information"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics: :Topics:
+#: >Topics> >Topics>
 #, no-wrap
 msgid "Preface"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics: :Topics:
+#: >Topics> >Topics>
 #, no-wrap
 msgid "Introduction"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Topics:
+#: >Topics>
 #, no-wrap
 msgid "Downloading_Fedora"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics:
+#: >Topics>
 #, no-wrap
 msgid "Downloading Fedora"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics:
+#: >Topics>
 #, no-wrap
 msgid "Installing Fedora"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Topics::Topics:
+#: >Topics>>Sub-Topics>
 #, no-wrap
 msgid "Preparing_for_Installation"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics::Topics:
+#: >Topics>>Sub-Topics>
 #, no-wrap
 msgid "Preparing for Installation"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Topics::Topics:
+#: >Topics>>Sub-Topics>
 #, no-wrap
 msgid "Booting_the_Installation"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics::Topics:
+#: >Topics>>Sub-Topics>
 #, no-wrap
 msgid "Booting the Installation"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Topics::Topics:
+#: >Topics>>Sub-Topics>
 #, no-wrap
 msgid "Installing_Using_Anaconda"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics::Topics:
+#: >Topics>>Sub-Topics>
 #, no-wrap
 msgid "Installing Using Anaconda"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Topics::Topics:
+#: >Topics>>Sub-Topics>
 #, no-wrap
 msgid "After_Installation"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics::Topics:
+#: >Topics>>Sub-Topics>
 #, no-wrap
 msgid "After the Installation"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Topics::Topics: :Topics::Topics:
+#: >Topics>>Sub-Topics> >Topics>>Sub-Topics>
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""

--- a/t/data-32/yamltest.po
+++ b/t/data-32/yamltest.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-05-26 15:07+0200\n"
+"POT-Creation-Date: 2018-05-25 08:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,235 +22,235 @@ msgid "en-US"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Level1:
+#: >Level1>
 #, no-wrap
 msgid "index"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1:
+#: >Level1>
 #, no-wrap
 msgid "Book Information"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1: :Level1:
+#: >Level1> >Level1>
 #, no-wrap
 msgid "Preface"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1: :Level1:
+#: >Level1> >Level1>
 #, no-wrap
 msgid "Introduction"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Level1:
+#: >Level1>
 #, no-wrap
 msgid "Downloading_Fedora"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1:
+#: >Level1>
 #, no-wrap
 msgid "Downloading Fedora"
 msgstr ""
 
 #. type: Hash Value - Key: Dir
-#: :Level1:
+#: >Level1>
 #, no-wrap
 msgid "install"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Level1::Level2-a:
+#: >Level1>>Level2-a>
 #, no-wrap
 msgid "Preparing_for_Installation"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1::Level2-a:
+#: >Level1>>Level2-a>
 #, no-wrap
 msgid "Preparing for Installation"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Level1::Level2-a:
+#: >Level1>>Level2-a>
 #, no-wrap
 msgid "Booting_the_Installation"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1::Level2-a:
+#: >Level1>>Level2-a>
 #, no-wrap
 msgid "Booting the Installation"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Level1::Level2-a:
+#: >Level1>>Level2-a>
 #, no-wrap
 msgid "Installing_Using_Anaconda"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1::Level2-a:
+#: >Level1>>Level2-a>
 #, no-wrap
 msgid "Installing Using Anaconda"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Level1::Level2-a:
+#: >Level1>>Level2-a>
 #, no-wrap
 msgid "After_Installation"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1::Level2-a:
+#: >Level1>>Level2-a>
 #, no-wrap
 msgid "After the Installation"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1::Level2-a: :Level1::Level2-a:
+#: >Level1>>Level2-a> >Level1>>Level2-a>
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1:
+#: >Level1>
 #, no-wrap
 msgid "Installing Fedora"
 msgstr ""
 
 #. type: Hash Value - Key: Dir
-#: :Level1:
+#: >Level1>
 #, no-wrap
 msgid "advanced"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Level1::Level2-b:
+#: >Level1>>Level2-b>
 #, no-wrap
 msgid "Boot_Options"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1::Level2-b:
+#: >Level1>>Level2-b>
 #, no-wrap
 msgid "Boot Options"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Level1::Level2-b:
+#: >Level1>>Level2-b>
 #, no-wrap
 msgid "Kickstart_Installations"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1::Level2-b:
+#: >Level1>>Level2-b>
 #, no-wrap
 msgid "Automating the Installation with Kickstart"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Level1::Level2-b:
+#: >Level1>>Level2-b>
 #, no-wrap
 msgid "Network_based_Installations"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1::Level2-b:
+#: >Level1>>Level2-b>
 #, no-wrap
 msgid "Setting Up an Installation Server"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Level1::Level2-b:
+#: >Level1>>Level2-b>
 #, no-wrap
 msgid "VNC_Installations"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1::Level2-b:
+#: >Level1>>Level2-b>
 #, no-wrap
 msgid "Installing Using VNC"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Level1::Level2-b:
+#: >Level1>>Level2-b>
 #, no-wrap
 msgid "Upgrading_Your_Current_System"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1::Level2-b:
+#: >Level1>>Level2-b>
 #, no-wrap
 msgid "Upgrading Your Current System"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1:
+#: >Level1>
 #, no-wrap
 msgid "Advanced Installation Options"
 msgstr ""
 
 #. type: Hash Value - Key: Dir
-#: :Level1:
+#: >Level1>
 #, no-wrap
 msgid "appendixes"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Level1::Level2-c:
+#: >Level1>>Level2-c>
 #, no-wrap
 msgid "Kickstart_Syntax_Reference"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1::Level2-c:
+#: >Level1>>Level2-c>
 #, no-wrap
 msgid "Kickstart Syntax Reference"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Level1::Level2-c:
+#: >Level1>>Level2-c>
 #, no-wrap
 msgid "Disk_Partitions"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1::Level2-c:
+#: >Level1>>Level2-c>
 #, no-wrap
 msgid "An Introduction to Disk Partitions"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Level1::Level2-c:
+#: >Level1>>Level2-c>
 #, no-wrap
 msgid "Understanding_LVM"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1::Level2-c:
+#: >Level1>>Level2-c>
 #, no-wrap
 msgid "Understanding LVM"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1:
+#: >Level1>
 #, no-wrap
 msgid "Technical Appendixes"
 msgstr ""
 
 #. type: Hash Value - Key: File
-#: :Level1:
+#: >Level1>
 #, no-wrap
 msgid "Revision_History"
 msgstr ""
 
 #. type: Hash Value - Key: Name
-#: :Level1:
+#: >Level1>
 #, no-wrap
 msgid "Revision History"
 msgstr ""
@@ -261,13 +261,13 @@ msgid "Fedora Installation Guide"
 msgstr ""
 
 #. type: Hash Value - Key: city
-#: :bill-to:address
+#: >bill-to>address
 #, no-wrap
 msgid "Royal Oak"
 msgstr ""
 
 #. type: Hash Value - Key: lines
-#: :bill-to:address
+#: >bill-to>address
 #, no-wrap
 msgid ""
 "458 Walkman Dr.\n"
@@ -275,25 +275,25 @@ msgid ""
 msgstr ""
 
 #. type: Hash Value - Key: postal
-#: :bill-to:address
+#: >bill-to>address
 #, no-wrap
 msgid "48046"
 msgstr ""
 
 #. type: Hash Value - Key: state
-#: :bill-to:address
+#: >bill-to>address
 #, no-wrap
 msgid "MI"
 msgstr ""
 
 #. type: Hash Value - Key: family
-#: :bill-to
+#: >bill-to
 #, no-wrap
 msgid "Dumars"
 msgstr ""
 
 #. type: Hash Value - Key: given
-#: :bill-to
+#: >bill-to
 #, no-wrap
 msgid "Chris"
 msgstr ""
@@ -309,49 +309,49 @@ msgid "34843"
 msgstr ""
 
 #. type: Hash Value - Key: description
-#: :product:
+#: >product>
 #, no-wrap
 msgid "Basketball"
 msgstr ""
 
 #. type: Hash Value - Key: price
-#: :product:
+#: >product>
 #, no-wrap
 msgid "450.00"
 msgstr ""
 
 #. type: Hash Value - Key: quantity
-#: :product:
+#: >product>
 #, no-wrap
 msgid "4"
 msgstr ""
 
 #. type: Hash Value - Key: sku
-#: :product:
+#: >product>
 #, no-wrap
 msgid "BL394D"
 msgstr ""
 
 #. type: Hash Value - Key: description
-#: :product:
+#: >product>
 #, no-wrap
 msgid "Super Hoop"
 msgstr ""
 
 #. type: Hash Value - Key: price
-#: :product:
+#: >product>
 #, no-wrap
 msgid "2392.00"
 msgstr ""
 
 #. type: Hash Value - Key: quantity
-#: :product:
+#: >product>
 #, no-wrap
 msgid "1"
 msgstr ""
 
 #. type: Hash Value - Key: sku
-#: :product:
+#: >product>
 #, no-wrap
 msgid "BL4438H"
 msgstr ""

--- a/t/data-32/yamlutf8.po
+++ b/t/data-32/yamlutf8.po
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Hash Value - Key: lang
-#: :meta
+#: >meta
 #, no-wrap
 msgid "日本語"
 msgstr ""


### PR DESCRIPTION
`//` is interpreted as `/` in UNIX path, so I'd prefer using `>` which doesn't have this convention.

```
-
  -
    - a
-
  -
    - b
```
```
#. type: Array Element
#: >>
#, no-wrap
msgid "a"
msgstr ""

#. type: Array Element
#: >>
#, no-wrap
msgid "b"
msgstr ""
```