### PR TITLE
Fix Asciidoc unindented lists

### DIFF
--- a/t/t-03-asciidoc/Lists.asciidoc
+++ b/t/t-03-asciidoc/Lists.asciidoc
@@ -36,6 +36,13 @@ a. Lowercase letter numbered list item with optional numbering.
   3. Donec eget arcu bibendum nunc consequat lobortis.
   4. Nam fermentum mattis ante.
 
+* List Item 1
+** Non-indented new list Item
+** Another Item
+* List Item 2
+* List Item 3
+** Non-indented new list Item 2
+
 Vertical Labeled Lists
 ----------------------
 

--- a/t/t-03-asciidoc/Lists.err
+++ b/t/t-03-asciidoc/Lists.err
@@ -1,2 +1,3 @@
 t-03-asciidoc/Lists.asciidoc:9: It seems that you are adding unindented content to an item.
-The "standard" allows this, but you may still want to fix your document.
+The standard allows this, but you may still want to change your document
+to use indented text to provide better visual clues to writers.

--- a/t/t-03-asciidoc/Lists.out
+++ b/t/t-03-asciidoc/Lists.out
@@ -34,6 +34,13 @@ a. Lowercase letter numbered list item with optional numbering.
   3. Donec eget arcu bibendum nunc consequat lobortis.
   4. Nam fermentum mattis ante.
 
+* List Item 1
+** Non-indented new list Item
+** Another Item
+* List Item 2
+* List Item 3
+** Non-indented new list Item 2
+
 Vertical Labeled Lists
 ----------------------
 

--- a/t/t-03-asciidoc/Lists.pot
+++ b/t/t-03-asciidoc/Lists.pot
@@ -64,7 +64,7 @@ msgid "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:19 t-03-asciidoc/Lists.asciidoc:26 t-03-asciidoc/Lists.asciidoc:28 t-03-asciidoc/Lists.asciidoc:32 t-03-asciidoc/Lists.asciidoc:33 t-03-asciidoc/Lists.asciidoc:44 t-03-asciidoc/Lists.asciidoc:46
+#: t-03-asciidoc/Lists.asciidoc:19 t-03-asciidoc/Lists.asciidoc:26 t-03-asciidoc/Lists.asciidoc:28 t-03-asciidoc/Lists.asciidoc:32 t-03-asciidoc/Lists.asciidoc:33 t-03-asciidoc/Lists.asciidoc:51 t-03-asciidoc/Lists.asciidoc:53
 msgid "Fusce euismod commodo velit."
 msgstr ""
 
@@ -76,12 +76,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:23 t-03-asciidoc/Lists.asciidoc:27 t-03-asciidoc/Lists.asciidoc:29 t-03-asciidoc/Lists.asciidoc:34 t-03-asciidoc/Lists.asciidoc:36 t-03-asciidoc/Lists.asciidoc:49 t-03-asciidoc/Lists.asciidoc:50 t-03-asciidoc/Lists.asciidoc:70 t-03-asciidoc/Lists.asciidoc:71 t-03-asciidoc/Lists.asciidoc:75
+#: t-03-asciidoc/Lists.asciidoc:23 t-03-asciidoc/Lists.asciidoc:27 t-03-asciidoc/Lists.asciidoc:29 t-03-asciidoc/Lists.asciidoc:34 t-03-asciidoc/Lists.asciidoc:36 t-03-asciidoc/Lists.asciidoc:56 t-03-asciidoc/Lists.asciidoc:57 t-03-asciidoc/Lists.asciidoc:77 t-03-asciidoc/Lists.asciidoc:78 t-03-asciidoc/Lists.asciidoc:82
 msgid "Vivamus fringilla mi eu lacus."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:24 t-03-asciidoc/Lists.asciidoc:30 t-03-asciidoc/Lists.asciidoc:35 t-03-asciidoc/Lists.asciidoc:37 t-03-asciidoc/Lists.asciidoc:51 t-03-asciidoc/Lists.asciidoc:53 t-03-asciidoc/Lists.asciidoc:72 t-03-asciidoc/Lists.asciidoc:76
+#: t-03-asciidoc/Lists.asciidoc:24 t-03-asciidoc/Lists.asciidoc:30 t-03-asciidoc/Lists.asciidoc:35 t-03-asciidoc/Lists.asciidoc:37 t-03-asciidoc/Lists.asciidoc:58 t-03-asciidoc/Lists.asciidoc:60 t-03-asciidoc/Lists.asciidoc:79 t-03-asciidoc/Lists.asciidoc:83
 msgid "Donec eget arcu bibendum nunc consequat lobortis."
 msgstr ""
 
@@ -100,87 +100,117 @@ msgstr ""
 msgid "Nam fermentum mattis ante."
 msgstr ""
 
-#. type: Title -
+#. type: Plain text
 #: t-03-asciidoc/Lists.asciidoc:40
+msgid "List Item 1"
+msgstr ""
+
+#. type: Plain text
+#: t-03-asciidoc/Lists.asciidoc:41
+msgid "Non-indented new list Item"
+msgstr ""
+
+#. type: Plain text
+#: t-03-asciidoc/Lists.asciidoc:42
+msgid "Another Item"
+msgstr ""
+
+#. type: Plain text
+#: t-03-asciidoc/Lists.asciidoc:43
+msgid "List Item 2"
+msgstr ""
+
+#. type: Plain text
+#: t-03-asciidoc/Lists.asciidoc:44
+msgid "List Item 3"
+msgstr ""
+
+#. type: Plain text
+#: t-03-asciidoc/Lists.asciidoc:45
+msgid "Non-indented new list Item 2"
+msgstr ""
+
+#. type: Title -
+#: t-03-asciidoc/Lists.asciidoc:47
 #, no-wrap
 msgid "Vertical Labeled Lists"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:42
+#: t-03-asciidoc/Lists.asciidoc:49
 #, no-wrap
 msgid "Lorem"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:47
+#: t-03-asciidoc/Lists.asciidoc:54
 #, no-wrap
 msgid "Ipsum"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:51
+#: t-03-asciidoc/Lists.asciidoc:58
 #, no-wrap
 msgid "Dolor"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:53
+#: t-03-asciidoc/Lists.asciidoc:60
 #, no-wrap
 msgid "Suspendisse"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:55
+#: t-03-asciidoc/Lists.asciidoc:62
 #, no-wrap
 msgid "A massa id sem aliquam auctor.\n"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:55
+#: t-03-asciidoc/Lists.asciidoc:62
 #, no-wrap
 msgid "Morbi"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:57
+#: t-03-asciidoc/Lists.asciidoc:64
 #, no-wrap
 msgid "Pretium nulla vel lorem.\n"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:57
+#: t-03-asciidoc/Lists.asciidoc:64
 #, no-wrap
 msgid "In"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:59
+#: t-03-asciidoc/Lists.asciidoc:66
 #, no-wrap
 msgid "Dictum mauris in urna.\n"
 msgstr ""
 
 #. type: Title -
-#: t-03-asciidoc/Lists.asciidoc:61
+#: t-03-asciidoc/Lists.asciidoc:68
 #, no-wrap
 msgid "Horizontal Labeled Lists"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:63
+#: t-03-asciidoc/Lists.asciidoc:70
 #, no-wrap
 msgid "*Lorem*"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:65
+#: t-03-asciidoc/Lists.asciidoc:72
 msgid ""
 "Fusce euismod commodo velit.  Qui in magna commodo, est labitur dolorum "
 "an. Est ne magna primis adolescens."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:68
+#: t-03-asciidoc/Lists.asciidoc:75
 #, no-wrap
 msgid ""
 "  Fusce euismod commodo velit.\n"
@@ -188,131 +218,131 @@ msgid ""
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:69
+#: t-03-asciidoc/Lists.asciidoc:76
 #, no-wrap
 msgid "*Ipsum*"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:73
+#: t-03-asciidoc/Lists.asciidoc:80
 #, no-wrap
 msgid "*Dolor*"
 msgstr ""
 
 #. type: Title -
-#: t-03-asciidoc/Lists.asciidoc:78
+#: t-03-asciidoc/Lists.asciidoc:85
 #, no-wrap
 msgid "Question and Answer Lists"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:79
+#: t-03-asciidoc/Lists.asciidoc:86
 #, no-wrap
 msgid "Question one"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:81
+#: t-03-asciidoc/Lists.asciidoc:88
 msgid "Answer one."
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:81
+#: t-03-asciidoc/Lists.asciidoc:88
 #, no-wrap
 msgid "Question two"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:83
+#: t-03-asciidoc/Lists.asciidoc:90
 msgid "Answer two."
 msgstr ""
 
 #. type: Title -
-#: t-03-asciidoc/Lists.asciidoc:85
+#: t-03-asciidoc/Lists.asciidoc:92
 #, no-wrap
 msgid "Glossary Lists"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:87
+#: t-03-asciidoc/Lists.asciidoc:94
 #, no-wrap
 msgid "A glossary term"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:89 t-03-asciidoc/Lists.asciidoc:91
+#: t-03-asciidoc/Lists.asciidoc:96 t-03-asciidoc/Lists.asciidoc:98
 msgid "The corresponding definition."
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:89
+#: t-03-asciidoc/Lists.asciidoc:96
 #, no-wrap
 msgid "A second glossary term"
 msgstr ""
 
 #. type: Title -
-#: t-03-asciidoc/Lists.asciidoc:93
+#: t-03-asciidoc/Lists.asciidoc:100
 #, no-wrap
 msgid "Bibliography Lists"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:97 t-03-asciidoc/Lists.asciidoc:107
+#: t-03-asciidoc/Lists.asciidoc:104 t-03-asciidoc/Lists.asciidoc:114
 msgid ""
 "[[[taoup]]] Eric Steven Raymond. 'The Art of UNIX "
 "Programming'. Addison-Wesley. ISBN 0-13-142901-9."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:99
+#: t-03-asciidoc/Lists.asciidoc:106
 msgid ""
 "[[[walsh-muellner]]] Norman Walsh & Leonard Muellner.  'DocBook - The "
 "Definitive Guide'. O'Reilly & Associates."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:100
+#: t-03-asciidoc/Lists.asciidoc:107
 msgid "ISBN 1-56592-580-7."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:102
+#: t-03-asciidoc/Lists.asciidoc:109
 msgid "The same in a bibliography section, and without the doc typo"
 msgstr ""
 
 #. type: Title -
-#: t-03-asciidoc/Lists.asciidoc:104
+#: t-03-asciidoc/Lists.asciidoc:111
 #, no-wrap
 msgid "Bibliography"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:110
+#: t-03-asciidoc/Lists.asciidoc:117
 msgid ""
 "[[[walsh-muellner]]] Norman Walsh & Leonard Muellner.  'DocBook - The "
 "Definitive Guide'. O'Reilly & Associates. 1999.  ISBN 1-56592-580-7."
 msgstr ""
 
 #. type: Title -
-#: t-03-asciidoc/Lists.asciidoc:112
+#: t-03-asciidoc/Lists.asciidoc:119
 #, no-wrap
 msgid "List Item Continuation"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:115 t-03-asciidoc/Lists.asciidoc:146
+#: t-03-asciidoc/Lists.asciidoc:122 t-03-asciidoc/Lists.asciidoc:153
 msgid "List item one."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:118
+#: t-03-asciidoc/Lists.asciidoc:125
 msgid ""
 "List item one continued with a second paragraph followed by an Indented "
 "block."
 msgstr ""
 
 #. type: delimited block .
-#: t-03-asciidoc/Lists.asciidoc:122
+#: t-03-asciidoc/Lists.asciidoc:129
 #, no-wrap
 msgid ""
 "$ ls *.sh\n"
@@ -320,17 +350,17 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:125
+#: t-03-asciidoc/Lists.asciidoc:132
 msgid "List item one continued with a third paragraph."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:127
+#: t-03-asciidoc/Lists.asciidoc:134
 msgid "List item two."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:130
+#: t-03-asciidoc/Lists.asciidoc:137
 #, no-wrap
 msgid ""
 "List item two literal paragraph (no continuation required).\n"
@@ -338,12 +368,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:132
+#: t-03-asciidoc/Lists.asciidoc:139
 msgid "Nested list (item one)."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:135
+#: t-03-asciidoc/Lists.asciidoc:142
 #, no-wrap
 msgid ""
 "Nested list literal paragraph (no continuation required).\n"
@@ -351,76 +381,76 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:137
+#: t-03-asciidoc/Lists.asciidoc:144
 msgid "Nested list appended list item one paragraph"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:139
+#: t-03-asciidoc/Lists.asciidoc:146
 msgid "Nested list item two."
 msgstr ""
 
 #. type: Title -
-#: t-03-asciidoc/Lists.asciidoc:142
+#: t-03-asciidoc/Lists.asciidoc:149
 #, no-wrap
 msgid "List Block"
 msgstr ""
 
 #. type: Block title
-#: t-03-asciidoc/Lists.asciidoc:144
+#: t-03-asciidoc/Lists.asciidoc:151
 #, no-wrap
 msgid "Nested List Block"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:148 t-03-asciidoc/Lists.asciidoc:153
+#: t-03-asciidoc/Lists.asciidoc:155 t-03-asciidoc/Lists.asciidoc:160
 msgid "This paragraph is part of the preceding list item"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:151
+#: t-03-asciidoc/Lists.asciidoc:158
 msgid "This list is nested and does not require explicit item continuation."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:155
+#: t-03-asciidoc/Lists.asciidoc:162
 msgid "List item b."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:157
+#: t-03-asciidoc/Lists.asciidoc:164
 msgid "This paragraph belongs to list item b."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:160
+#: t-03-asciidoc/Lists.asciidoc:167
 msgid "This paragraph belongs to item 1."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:162
+#: t-03-asciidoc/Lists.asciidoc:169
 msgid "Item 2 of the outer list."
 msgstr ""
 
 #. type: Block title
-#: t-03-asciidoc/Lists.asciidoc:163
+#: t-03-asciidoc/Lists.asciidoc:170
 #, no-wrap
 msgid "Literal Paragraph in a Vertical Labeled Lists"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:166
+#: t-03-asciidoc/Lists.asciidoc:173
 msgid "This comes from the git doc, on which po4a used to fail miserably."
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:167
+#: t-03-asciidoc/Lists.asciidoc:174
 #, no-wrap
 msgid "patch"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:174
+#: t-03-asciidoc/Lists.asciidoc:181
 msgid ""
 "This lets you choose one path out of a 'status' like selection.  After "
 "choosing the path, it presents the diff between the index and the working "
@@ -429,7 +459,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:189
+#: t-03-asciidoc/Lists.asciidoc:196
 #, no-wrap
 msgid ""
 "y - stage this hunk\n"
@@ -449,7 +479,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:191
+#: t-03-asciidoc/Lists.asciidoc:198
 msgid ""
 "After deciding the fate for all hunks, if there is any hunk that was chosen, "
 "the index is updated with the selected hunks."


### PR DESCRIPTION
Lists are not required to be indented.  This fixes them to put separate items in the .pot file