### PR TITLE
asciidoc: do not include table fences in pot

### DIFF
--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -665,23 +665,21 @@ sub parse {
 		    undef $self->{indent};
         } elsif ($line =~ /^\|===/) {
             # This is a table, treat it as a non-wrapped paragraph
-            # TODO: Can we not add table delimeters to .pot?
             # TODO: Consider whether this should really try to deconstruct it by cell
             print STDERR "Found Table delimiter\n" if ($debug{parse});
             if (($paragraph eq "") or (defined($self->{type}) and ($self->{type} =~ /^delimited block/i))) {
                 # Start the table
                 $wrapped_mode = 0;
                 $self->{type} = "Table";
-                $paragraph .= $line."\n";
             } else {
                 # End the Table
-                $paragraph .= $line."\n";
                 do_paragraph($self,$paragraph,$wrapped_mode);
                 undef $self->{verbatim};
                 undef $self->{type};
                 $wrapped_mode = 1;
                 $paragraph="";
             }
+            $self->pushline($line."\n")
         } else {
 	    # A stupid paragraph of text
 	    print STDERR "Regular line. ".

--- a/t/t-03-asciidoc/Tables.pot
+++ b/t/t-03-asciidoc/Tables.pot
@@ -26,11 +26,9 @@ msgstr ""
 #: t-03-asciidoc/Tables.asciidoc:8
 #, no-wrap
 msgid ""
-"|===\n"
 "|1 | 2\n"
 "|3 | 4\n"
 "|5 | 6\n"
-"|===\n"
 msgstr ""
 
 #. type: Block title
@@ -43,34 +41,28 @@ msgstr ""
 #: t-03-asciidoc/Tables.asciidoc:19
 #, no-wrap
 msgid ""
-"|===\n"
 "|Column 1 | Column 2\n"
 "|1        | Item 1\n"
 "|2        | Item 2\n"
 "|3        | Item 3\n"
 "|6        | Three items\n"
-"|===\n"
 msgstr ""
 
 #. type: Table
 #: t-03-asciidoc/Tables.asciidoc:26
 #, no-wrap
 msgid ""
-"|===\n"
 "|1|2|3|4\n"
 "|a|b|c|d\n"
 "|A|B|C|D\n"
-"|===\n"
 msgstr ""
 
 #. type: Table
 #: t-03-asciidoc/Tables.asciidoc:32
 #, no-wrap
 msgid ""
-"|===\n"
 "ID,Customer Name,Contact Name,Customer Address,Phone\n"
 "include::customers.csv[]\n"
-"|===\n"
 msgstr ""
 
 #. type: Plain text
@@ -85,7 +77,6 @@ msgstr ""
 #: t-03-asciidoc/Tables.asciidoc:63
 #, no-wrap
 msgid ""
-"|===\n"
 "|Option|Description\n"
 "|[option]`Charset` = __encoding__|Specifies the character set of a generated "
 "web page. The _encoding_ has to be a valid character set such as `UTF-8` or "
@@ -138,7 +129,6 @@ msgid ""
 "in the expected manner.\n"
 "|[option]`XHTML`|Enables the use of XHTML 1.0 instead of the default HTML "
 "3.2.\n"
-"|===\n"
 msgstr ""
 
 #. type: Plain text
@@ -150,7 +140,6 @@ msgstr ""
 #: t-03-asciidoc/Tables.asciidoc:78
 #, no-wrap
 msgid ""
-"|===\n"
 "|Option|Description\n"
 "|[option]`Charset` = __encoding__\n"
 "|Specifies the character set of a generated web page. The _encoding_ has to "
@@ -164,5 +153,4 @@ msgid ""
 "|Specifies the width of the description column. The _value_ can be either a "
 "number of characters, or an asterisk (that is, `*`) to adjust the width "
 "automatically.\n"
-"|===\n"
 msgstr ""


### PR DESCRIPTION
This is the previous behavior and it should be preserved at least.