### PR TITLE
asciidoc: add option to prevent translation of image targets

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,7 @@ AsciiDoc:
  * Fix Asciidoc unindented lists (GitHub's #149)
  * Make Asciidoc Tables nowrap and support current format (GitHub's #63)
  * Do not include table fences in pot file (GitHub's #163)
+ * Add option to prevent translation of target of image blocks.
 
 Markdown:
  * Improve markdown ruler parsing, and add test.

--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -60,6 +60,10 @@ Space-separated list of macro definitions.
 
 Space-separated list of style definitions.
 
+=item B<noimagetargets>
+
+By default, the targets of block images are translatable to give opportunity to make the content point to translated images. This can be stopped by setting this option.
+
 =back
 
 =head1 INLINE CUSTOMIZATION
@@ -128,6 +132,7 @@ sub initialize {
     $self->{options}{'macro'}='';
     $self->{options}{'style'}='';
     $self->{options}{'definitions'}='';
+    $self->{options}{'noimagetargets'} = 0;
 
     foreach my $opt (keys %options) {
         die wrap_mod("po4a::asciidoc",
@@ -153,7 +158,7 @@ sub initialize {
     $self->register_attributelist('[icon]');
     $self->register_attributelist('[caption]');
     $self->register_attributelist('[-icons,caption]');
-    $self->register_macro('image_[1,alt,title,link]');
+    $self->register_macro('image_[1,alt,title,link]') unless $self->{options}{'noimagetargets'};
 
     if ($self->{options}{'definitions'}) {
         $self->parse_definition_file($self->{options}{'definitions'})

--- a/t/03-asciidoc.t
+++ b/t/03-asciidoc.t
@@ -28,6 +28,11 @@ foreach my $AsciiDocTest (@AsciiDocTests) {
 
 push @tests,
   {
+    'normalize' => "-f asciidoc -o noimagetargets=1 t-03-asciidoc/NoImageTarget.asciidoc",
+    'doc'      => "test ignoring image targets",
+    'requires' => "Unicode::GCString"
+  },
+  {
     'run' =>
 "perl ../po4a-gettextize -f asciidoc -m t-03-asciidoc/Titles.asciidoc -l t-03-asciidoc/TitlesUTF8.asciidoc -L UTF-8 -p tmp/TitlesUTF8.po",
     'test' =>

--- a/t/t-03-asciidoc/NoImageTarget.asciidoc
+++ b/t/t-03-asciidoc/NoImageTarget.asciidoc
@@ -1,0 +1,19 @@
+Test Images targets
+===========================================
+
+Image Targets
+-------------
+
+Paragraph before blockimage
+image::foo.png[Block image Alt]
+paragraph after blockimage
+
+image::foo.png["Block image with title", title="My image title"]
+
+.External image title
+image::foo.png["Block image with external title"]
+
+image::foo.png[title="Image with title but without alt-text"]
+
+Block image macro without alt text:
+image::foo.png[]

--- a/t/t-03-asciidoc/NoImageTarget.out
+++ b/t/t-03-asciidoc/NoImageTarget.out
@@ -1,0 +1,19 @@
+Test Images targets
+===========================================
+
+Image Targets
+-------------
+
+Paragraph before blockimage
+image::foo.png[Block image Alt]
+paragraph after blockimage
+
+image::foo.png["Block image with title", title="My image title"]
+
+.External image title
+image::foo.png["Block image with external title"]
+
+image::foo.png[title="Image with title but without alt-text"]
+
+Block image macro without alt text:
+image::foo.png[]

--- a/t/t-03-asciidoc/NoImageTarget.pot
+++ b/t/t-03-asciidoc/NoImageTarget.pot
@@ -1,0 +1,49 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2018-12-02 17:37+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Plain text
+#: t-03-asciidoc/NoImageTarget.asciidoc:2
+msgid "Test Images targets"
+msgstr ""
+
+#. type: Title -
+#: t-03-asciidoc/NoImageTarget.asciidoc:5
+#, no-wrap
+msgid "Image Targets"
+msgstr ""
+
+#. type: delimited block =
+#: t-03-asciidoc/NoImageTarget.asciidoc:8
+msgid "Paragraph before blockimage"
+msgstr ""
+
+#. type: delimited block =
+#: t-03-asciidoc/NoImageTarget.asciidoc:10
+msgid "paragraph after blockimage"
+msgstr ""
+
+#. type: Block title
+#: t-03-asciidoc/NoImageTarget.asciidoc:13
+#, no-wrap
+msgid "External image title"
+msgstr ""
+
+#. type: delimited block =
+#: t-03-asciidoc/NoImageTarget.asciidoc:19
+msgid "Block image macro without alt text:"
+msgstr ""


### PR DESCRIPTION
Most of the time, the images are relative to the asciidoc files and
don't need special processing. This option does not change the default
behavior, so that existing projects are not broken.