### PR TITLE
[asciidoc] add basic table cells support

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,7 +8,8 @@ __   __/ _ \ | ___| / /_
  \ V /| |_| | ___) | (_) |
   \_/  \___(_)____/ \___/      (not released yet)
 
-
+AsciiDoc:
+ * Introduce option tablecells to process cells in tables.
 
 =======================================================================
         ___   ____ ____

--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -133,6 +133,7 @@ sub initialize {
     $self->{options}{'style'}='';
     $self->{options}{'definitions'}='';
     $self->{options}{'noimagetargets'} = 0;
+    $self->{options}{'tablecells'}=0;
 
     foreach my $opt (keys %options) {
         die wrap_mod("po4a::asciidoc",
@@ -317,6 +318,42 @@ sub parse {
             } else {
                 push @comments, $line;
             }
+        } elsif ((defined $self->{type}) and ($self->{type} eq "Table") and ($line !~ m/^\|===/) and ($self->{options}{"tablecells"})) {
+            # inside a table
+            my $new_line = "";
+            my @texts = split /(?:(?:\d+|\d*(?:\.\d+)?)(?:\+|\*))?[<^>]?(?:\.[<^>])?[demshalv]?\|/, $line;
+            my @seps = ($line)=~ m/(?:(?:\d+|\d*(?:\.\d+)?)(?:\+|\*))?[<^>]?(?:\.[<^>])?[demshalv]?\|/g;
+            if ((scalar(@texts) and length($texts[0])) || (!length($line))) {
+                if (!length($line)) { $texts[0] = "";}
+                if (length($paragraph)) {
+                    # if we are in a continuation line
+                    $paragraph .= "\n" . $texts[0];
+                } else {
+                    $paragraph = $texts[0];
+                    $self->pushline("\n");
+                }
+            } elsif (length($paragraph)) {
+                $new_line = "\n";
+            }
+
+            shift @texts;
+            my @parts = map { ( $_ , shift @texts ) } @seps;
+            foreach my $part (@parts) {
+                if ($part =~ /\|$/) {
+                    # this is a cell separator. End the previous cell
+                    do_stripped_unwrapped_paragraph($self, $paragraph, $wrapped_mode);
+                    if ($new_line eq "\n") {
+                        $self->pushline("\n");
+                        $new_line = "";
+                    }
+                    $paragraph = "";
+                    $self->pushline($part);
+                } else {
+                    # this is content. Append it.
+                    $paragraph .= $part;
+                }
+            }
+
         } elsif ((not defined($self->{verbatim})) and ($line =~ m/^(\+|--)$/)) {
             # List Item Continuation or List Block
             do_paragraph($self,$paragraph,$wrapped_mode);
@@ -678,10 +715,14 @@ sub parse {
                 $self->{type} = "Table";
             } else {
                 # End the Table
-                do_paragraph($self,$paragraph,$wrapped_mode);
+                if ($self->{options}{'tablecells'}) {
+                    do_stripped_unwrapped_paragraph($self, $paragraph, $wrapped_mode);
+                    $self->pushline("\n");
+                } else {
+                    do_paragraph($self, $paragraph, $wrapped_mode);
+                }
                 undef $self->{verbatim};
                 undef $self->{type};
-                $wrapped_mode = 1;
                 $paragraph="";
             }
             $self->pushline($line."\n")
@@ -722,6 +763,15 @@ sub parse {
     if (length $paragraph) {
         do_paragraph($self,$paragraph,$wrapped_mode);
     }
+}
+
+sub do_stripped_unwrapped_paragraph {
+    my ($self, $paragraph, $wrap) = (shift, shift, shift);
+    my $type = shift || $self->{type} || "Plain text";
+    my ($pre, $trans, $post) = $paragraph =~ /^(\s*)(.*?)(\s*)$/s;
+    $self->pushline($pre);
+    do_paragraph($self, $trans, $wrap, $type);
+    $self->pushline($post);
 }
 
 sub do_paragraph {

--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -62,7 +62,14 @@ Space-separated list of style definitions.
 
 =item B<noimagetargets>
 
-By default, the targets of block images are translatable to give opportunity to make the content point to translated images. This can be stopped by setting this option.
+By default, the targets of block images are translatable to give opportunity
+to make the content point to translated images. This can be stopped by setting
+this option.
+
+=item B<tablecells>
+
+This option is a flag that enables sub-table segmentation into cell content.
+The segmentation is limited to cell content, without any parsing inside of it.
 
 =back
 

--- a/t/03-asciidoc.t
+++ b/t/03-asciidoc.t
@@ -57,6 +57,10 @@ push @tests,
     'requires' => "Unicode::GCString"
   },
   {
+    'normalize' => "-f asciidoc -o tablecells=1 t-03-asciidoc/TablesCells.asciidoc",
+    'doc'       => "Table cells test"
+  },
+  {
     'run' =>
 "msgattrib --clear-fuzzy -o tmp/TitlesLatin1.po tmp/TitlesLatin1.po && perl ../po4a-translate -f asciidoc -m t-03-asciidoc/Titles.asciidoc -l tmp/TitlesLatin1.asciidoc -p tmp/TitlesLatin1.po",
     'test' =>

--- a/t/t-03-asciidoc/TablesCells.asciidoc
+++ b/t/t-03-asciidoc/TablesCells.asciidoc
@@ -1,0 +1,141 @@
+Tables with Cells translated
+============================
+
+Examples taken from asciidoctor table guide
+
+.Simple table
+|===
+| Cell in column 1, row 1 | Cell in column 2, row 1
+| Cell in column 1, row 2 | Cell in column 2, row 2
+| Cell in column 1, row 3 | Cell in column 2, row 3
+|===
+
+.No space around column separator
+|===
+|Cell in column 1, row 1|Cell in column 2, row 1
+|===
+
+.Cells on each line
+[cols="3*"]
+|===
+|Cell in column 1, row 1
+|Cell in column 2, row 1
+|Cell in column 3, row 1
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+|===
+
+.Cell duplicated
+|===
+|Cell in column 1, row 1 |Cell in column 2, row 1 |Cell in column 3, row 1
+3*|Same cell content in columns 1, 2, and 3
+|Cell in column 1, row 3
+|Cell in column 2, row 3
+|Cell in column 3, row 3
+|===
+
+.Cell span
+|===
+
+|Cell in column 1, row 1 |Cell in column 2, row 1 |Cell in column 3, row 1
+
+3+|Content in a single cell that spans columns 1, 2, and 3
+
+|Cell in column 1, row 3
+|Cell in column 2, row 3
+|Cell in column 3, row 3
+
+|===
+
+.Cell span in rows
+|===
+
+|Cell in column 1, row 1 |Cell in column 2, row 1 |Cell in column 3, row 1
+
+.2+|Content in a single cell that spans rows 2 and 3
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+
+|Cell in column 2, row 3
+|Cell in column 3, row 3
+
+|===
+
+.Cell span in columns and rows
+|===
+
+|Column 1, row 1 |Column 2, row 1 |Column 3, row 1 |Column 4, row 1
+
+|Column 1, row 2
+2.3+|Content in a single cell that spans over rows and columns
+|Column 4, row 2
+
+|Column 1, row 3
+|Column 4, row 3
+
+|Column 1, row 4
+|Column 4, row 4
+|===
+
+.Cells aligned horizontally, vertically, and across a span of three columns
+[cols="3"]
+|===
+^|Prefix the `{vbar}` with `{caret}` to center content horizontally
+<|Prefix the `{vbar}` with `<` to align the content to the left horizontally
+>|Prefix the `{vbar}` with `>` to align the content to the right horizontally
+
+.^|Prefix the `{vbar}` with a `.` and `{caret}` to center the content in the cell vertically
+.<|Prefix the `{vbar}` with a `.` and `<` to align the content to the top of the cell
+.>|Prefix the `{vbar}` with a `.` and `>` to align the content to the bottom of the cell
+
+3+^.^|This content spans three columns (`3{plus}`) and is centered horizontally (`{caret}`) and vertically (`.{caret}`) within the cell.
+
+|===
+
+.Building a variety of cell specifiers
+|===
+
+2*>m|This content is duplicated across two columns.
+
+It is aligned right horizontally.
+
+And it is monospaced.
+
+.3+^.>s|This cell spans 3 rows. The content is centered horizontally, aligned to the bottom of the cell, and strong.
+e|This content is emphasized.
+
+.^l|This content is aligned to the top of the cell and literal.
+
+v|This cell contains a verse
+that may one day expound on the
+wonders of tables in an
+epic sonnet.
+
+|===
+
+.Cells with Asciidoc in them
+[cols="2"]
+|===
+
+a|This cell is prefixed with an `a`, so the processor interprets the following lines as an AsciiDoc list.
+
+* List item 1
+* List item 2
+* List item 3
+|This cell *is not* prefixed with an `a`, so the processor does not interpret the following lines as an AsciiDoc list.
+
+* List item 1
+* List item 2
+* List item 3
+
+a|This cell is prefixed with an `a`, so the processor honors the `lead` style on the following paragraph.
+
+[.lead]
+I am a paragraph styled with the lead attribute.
+|This cell *is not* prefixed with an `a`, so the processor does not honor the `lead` style on the following paragraph.
+
+[.lead]
+I am a paragraph styled with the lead attribute.
+|===

--- a/t/t-03-asciidoc/TablesCells.out
+++ b/t/t-03-asciidoc/TablesCells.out
@@ -1,0 +1,141 @@
+Tables with Cells translated
+============================
+
+Examples taken from asciidoctor table guide
+
+.Simple table
+|===
+| Cell in column 1, row 1 | Cell in column 2, row 1
+| Cell in column 1, row 2 | Cell in column 2, row 2
+| Cell in column 1, row 3 | Cell in column 2, row 3
+|===
+
+.No space around column separator
+|===
+|Cell in column 1, row 1|Cell in column 2, row 1
+|===
+
+.Cells on each line
+[cols="3*"]
+|===
+|Cell in column 1, row 1
+|Cell in column 2, row 1
+|Cell in column 3, row 1
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+|===
+
+.Cell duplicated
+|===
+|Cell in column 1, row 1 |Cell in column 2, row 1 |Cell in column 3, row 1
+3*|Same cell content in columns 1, 2, and 3
+|Cell in column 1, row 3
+|Cell in column 2, row 3
+|Cell in column 3, row 3
+|===
+
+.Cell span
+|===
+
+|Cell in column 1, row 1 |Cell in column 2, row 1 |Cell in column 3, row 1
+
+3+|Content in a single cell that spans columns 1, 2, and 3
+
+|Cell in column 1, row 3
+|Cell in column 2, row 3
+|Cell in column 3, row 3
+
+|===
+
+.Cell span in rows
+|===
+
+|Cell in column 1, row 1 |Cell in column 2, row 1 |Cell in column 3, row 1
+
+.2+|Content in a single cell that spans rows 2 and 3
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+
+|Cell in column 2, row 3
+|Cell in column 3, row 3
+
+|===
+
+.Cell span in columns and rows
+|===
+
+|Column 1, row 1 |Column 2, row 1 |Column 3, row 1 |Column 4, row 1
+
+|Column 1, row 2
+2.3+|Content in a single cell that spans over rows and columns
+|Column 4, row 2
+
+|Column 1, row 3
+|Column 4, row 3
+
+|Column 1, row 4
+|Column 4, row 4
+|===
+
+.Cells aligned horizontally, vertically, and across a span of three columns
+[cols="3"]
+|===
+^|Prefix the `{vbar}` with `{caret}` to center content horizontally
+<|Prefix the `{vbar}` with `<` to align the content to the left horizontally
+>|Prefix the `{vbar}` with `>` to align the content to the right horizontally
+
+.^|Prefix the `{vbar}` with a `.` and `{caret}` to center the content in the cell vertically
+.<|Prefix the `{vbar}` with a `.` and `<` to align the content to the top of the cell
+.>|Prefix the `{vbar}` with a `.` and `>` to align the content to the bottom of the cell
+
+3+^.^|This content spans three columns (`3{plus}`) and is centered horizontally (`{caret}`) and vertically (`.{caret}`) within the cell.
+
+|===
+
+.Building a variety of cell specifiers
+|===
+
+2*>m|This content is duplicated across two columns.
+
+It is aligned right horizontally.
+
+And it is monospaced.
+
+.3+^.>s|This cell spans 3 rows. The content is centered horizontally, aligned to the bottom of the cell, and strong.
+e|This content is emphasized.
+
+.^l|This content is aligned to the top of the cell and literal.
+
+v|This cell contains a verse
+that may one day expound on the
+wonders of tables in an
+epic sonnet.
+
+|===
+
+.Cells with Asciidoc in them
+[cols="2"]
+|===
+
+a|This cell is prefixed with an `a`, so the processor interprets the following lines as an AsciiDoc list.
+
+* List item 1
+* List item 2
+* List item 3
+|This cell *is not* prefixed with an `a`, so the processor does not interpret the following lines as an AsciiDoc list.
+
+* List item 1
+* List item 2
+* List item 3
+
+a|This cell is prefixed with an `a`, so the processor honors the `lead` style on the following paragraph.
+
+[.lead]
+I am a paragraph styled with the lead attribute.
+|This cell *is not* prefixed with an `a`, so the processor does not honor the `lead` style on the following paragraph.
+
+[.lead]
+I am a paragraph styled with the lead attribute.
+|===

--- a/t/t-03-asciidoc/TablesCells.pot
+++ b/t/t-03-asciidoc/TablesCells.pot
@@ -1,0 +1,363 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2018-12-09 22:02+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Title =
+#: t-03-asciidoc/TablesCells.asciidoc:2
+#, no-wrap
+msgid "Tables with Cells translated"
+msgstr ""
+
+#. type: Plain text
+#: t-03-asciidoc/TablesCells.asciidoc:5
+msgid "Examples taken from asciidoctor table guide"
+msgstr ""
+
+#. type: Block title
+#: t-03-asciidoc/TablesCells.asciidoc:6
+#, no-wrap
+msgid "Simple table"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:8 t-03-asciidoc/TablesCells.asciidoc:15 t-03-asciidoc/TablesCells.asciidoc:22 t-03-asciidoc/TablesCells.asciidoc:32 t-03-asciidoc/TablesCells.asciidoc:42 t-03-asciidoc/TablesCells.asciidoc:55
+#, no-wrap
+msgid "Cell in column 1, row 1"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:9 t-03-asciidoc/TablesCells.asciidoc:16 t-03-asciidoc/TablesCells.asciidoc:23 t-03-asciidoc/TablesCells.asciidoc:32 t-03-asciidoc/TablesCells.asciidoc:42 t-03-asciidoc/TablesCells.asciidoc:55
+#, no-wrap
+msgid "Cell in column 2, row 1"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:9 t-03-asciidoc/TablesCells.asciidoc:26
+#, no-wrap
+msgid "Cell in column 1, row 2"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:10 t-03-asciidoc/TablesCells.asciidoc:27 t-03-asciidoc/TablesCells.asciidoc:59
+#, no-wrap
+msgid "Cell in column 2, row 2"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:10 t-03-asciidoc/TablesCells.asciidoc:35 t-03-asciidoc/TablesCells.asciidoc:47
+#, no-wrap
+msgid "Cell in column 1, row 3"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:11 t-03-asciidoc/TablesCells.asciidoc:36 t-03-asciidoc/TablesCells.asciidoc:48 t-03-asciidoc/TablesCells.asciidoc:62
+#, no-wrap
+msgid "Cell in column 2, row 3"
+msgstr ""
+
+#. type: Block title
+#: t-03-asciidoc/TablesCells.asciidoc:13
+#, no-wrap
+msgid "No space around column separator"
+msgstr ""
+
+#. type: Block title
+#: t-03-asciidoc/TablesCells.asciidoc:18
+#, no-wrap
+msgid "Cells on each line"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:25 t-03-asciidoc/TablesCells.asciidoc:33 t-03-asciidoc/TablesCells.asciidoc:44 t-03-asciidoc/TablesCells.asciidoc:57
+#, no-wrap
+msgid "Cell in column 3, row 1"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:28 t-03-asciidoc/TablesCells.asciidoc:61
+#, no-wrap
+msgid "Cell in column 3, row 2"
+msgstr ""
+
+#. type: Block title
+#: t-03-asciidoc/TablesCells.asciidoc:30
+#, no-wrap
+msgid "Cell duplicated"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:34
+#, no-wrap
+msgid "Same cell content in columns 1, 2, and 3"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:37 t-03-asciidoc/TablesCells.asciidoc:50 t-03-asciidoc/TablesCells.asciidoc:64
+#, no-wrap
+msgid "Cell in column 3, row 3"
+msgstr ""
+
+#. type: Block title
+#: t-03-asciidoc/TablesCells.asciidoc:39
+#, no-wrap
+msgid "Cell span"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:46
+#, no-wrap
+msgid "Content in a single cell that spans columns 1, 2, and 3"
+msgstr ""
+
+#. type: Block title
+#: t-03-asciidoc/TablesCells.asciidoc:52
+#, no-wrap
+msgid "Cell span in rows"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:58
+#, no-wrap
+msgid "Content in a single cell that spans rows 2 and 3"
+msgstr ""
+
+#. type: Block title
+#: t-03-asciidoc/TablesCells.asciidoc:66
+#, no-wrap
+msgid "Cell span in columns and rows"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:69
+#, no-wrap
+msgid "Column 1, row 1"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:69
+#, no-wrap
+msgid "Column 2, row 1"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:69
+#, no-wrap
+msgid "Column 3, row 1"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:71
+#, no-wrap
+msgid "Column 4, row 1"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:72
+#, no-wrap
+msgid "Column 1, row 2"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:73
+#, no-wrap
+msgid "Content in a single cell that spans over rows and columns"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:75
+#, no-wrap
+msgid "Column 4, row 2"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:76
+#, no-wrap
+msgid "Column 1, row 3"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:78
+#, no-wrap
+msgid "Column 4, row 3"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:79
+#, no-wrap
+msgid "Column 1, row 4"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:80
+#, no-wrap
+msgid "Column 4, row 4"
+msgstr ""
+
+#. type: Block title
+#: t-03-asciidoc/TablesCells.asciidoc:82
+#, no-wrap
+msgid "Cells aligned horizontally, vertically, and across a span of three columns"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:86
+#, no-wrap
+msgid "Prefix the `{vbar}` with `{caret}` to center content horizontally"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:87
+#, no-wrap
+msgid "Prefix the `{vbar}` with `<` to align the content to the left horizontally"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:89
+#, no-wrap
+msgid "Prefix the `{vbar}` with `>` to align the content to the right horizontally"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:90
+#, no-wrap
+msgid ""
+"Prefix the `{vbar}` with a `.` and `{caret}` to center the content in the "
+"cell vertically"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:91
+#, no-wrap
+msgid ""
+"Prefix the `{vbar}` with a `.` and `<` to align the content to the top of "
+"the cell"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:93
+#, no-wrap
+msgid ""
+"Prefix the `{vbar}` with a `.` and `>` to align the content to the bottom of "
+"the cell"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:95
+#, no-wrap
+msgid ""
+"This content spans three columns (`3{plus}`) and is centered horizontally "
+"(`{caret}`) and vertically (`.{caret}`) within the cell."
+msgstr ""
+
+#. type: Block title
+#: t-03-asciidoc/TablesCells.asciidoc:97
+#, no-wrap
+msgid "Building a variety of cell specifiers"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:106
+#, no-wrap
+msgid ""
+"This content is duplicated across two columns.\n"
+"\n"
+"It is aligned right horizontally.\n"
+"\n"
+"And it is monospaced."
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:107
+#, no-wrap
+msgid ""
+"This cell spans 3 rows. The content is centered horizontally, aligned to the "
+"bottom of the cell, and strong."
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:109
+#, no-wrap
+msgid "This content is emphasized."
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:111
+#, no-wrap
+msgid "This content is aligned to the top of the cell and literal."
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:116
+#, no-wrap
+msgid ""
+"This cell contains a verse\n"
+"that may one day expound on the\n"
+"wonders of tables in an\n"
+"epic sonnet."
+msgstr ""
+
+#. type: Block title
+#: t-03-asciidoc/TablesCells.asciidoc:118
+#, no-wrap
+msgid "Cells with Asciidoc in them"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:127
+#, no-wrap
+msgid ""
+"This cell is prefixed with an `a`, so the processor interprets the following "
+"lines as an AsciiDoc list.\n"
+"\n"
+"* List item 1\n"
+"* List item 2\n"
+"* List item 3"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:133
+#, no-wrap
+msgid ""
+"This cell *is not* prefixed with an `a`, so the processor does not interpret "
+"the following lines as an AsciiDoc list.\n"
+"\n"
+"* List item 1\n"
+"* List item 2\n"
+"* List item 3"
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:137
+#, no-wrap
+msgid ""
+"This cell is prefixed with an `a`, so the processor honors the `lead` style "
+"on the following paragraph.\n"
+"\n"
+"[.lead]\n"
+"I am a paragraph styled with the lead attribute."
+msgstr ""
+
+#. type: Table
+#: t-03-asciidoc/TablesCells.asciidoc:141
+#, no-wrap
+msgid ""
+"This cell *is not* prefixed with an `a`, so the processor does not honor the "
+"`lead` style on the following paragraph.\n"
+"\n"
+"[.lead]\n"
+"I am a paragraph styled with the lead attribute."
+msgstr ""


### PR DESCRIPTION
For test and comment :+1: 

This PR introduces the management of table cells in asciidoc. The support for now is very basic and has some known limitations:

 * escaped  | are not managed. I couldn't come up with a correct regexp which would reject them. Maybe they can be managed later.
 * for cells that contain asciidoc block formatting ("a|" cells), the content is processed as a verbatim block. The general rule is that if a cell content spans on two lines or more, the text is treated as verbatim.

Both limitations may be released in the future. They are less prioritary because making complex stuff in tables is generally discouraged or thrown upon: this usually a smell that a table is used for formatting purpose and not for presentation of tabular data.

This behavior breaks the previous one, so it is introduced as an option `tablecells` of asciidoc plugin.

**TODO**: if accepted, 
 * add an entry in NEWS
 * document the option