### PR TITLE
asciidoc: do not crash if cell is nothing

### DIFF
--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -346,6 +346,7 @@ sub parse {
             shift @texts;
             my @parts = map { ( $_ , shift @texts ) } @seps;
             foreach my $part (@parts) {
+                if (!$part) {next}
                 if ($part =~ /\|$/) {
                     # this is a cell separator. End the previous cell
                     do_stripped_unwrapped_paragraph($self, $paragraph, $wrapped_mode);


### PR DESCRIPTION
For some reason, the content of a cell may be null.