### PR TITLE
YAML Front Matter fixups

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,7 +11,7 @@ __   __/ _ \ | ___| ( _ )
 Markdown:
  * Avoid translating Markdown fenced code block info string (GitHub's #194)
  * List Markdown fenced code block info string as text type (GitHub's #195)
- * Support YAML front matter (GitHub's #196). This requires YAML::Tiny.
+ * Support YAML Front Matter (GitHub's #196). This requires YAML::Tiny.
 
 Documentation:
  * Various cleanups by Golubev Alexander (GitHub's #190 & #191)

--- a/lib/Locale/Po4a/Text.pm
+++ b/lib/Locale/Po4a/Text.pm
@@ -518,12 +518,9 @@ sub parse_markdown_bibliographic_information {
 # Support YAML Front Matter in Markdown documents
 #
 # If the text starts with a YAML ---\n separator, the full text until
-# the next YAML ---\n separator is considered YAML metadata.
-#
-# If the information spans multiple lines, the following
-# lines must be indented with space.
-# If information is omitted, it's just a percent sign
-# and a blank line.
+# the next YAML ---\n separator is considered YAML metadata. The ...\n
+# "end of document" separator can be used at the end of the YAML
+# block.
 #
 sub parse_markdown_yaml_front_matter {
     my ($self,$line,$blockref) = @_;
@@ -531,7 +528,7 @@ sub parse_markdown_yaml_front_matter {
     my $yfm;
     ($nextline, $nextref) = $self->shiftline();
     while (defined($nextline)) {
-        last if ($nextline =~ /^---$/);
+        last if ($nextline =~ /^(---|\.\.\.)$/);
         $yfm .= $nextline;
         ($nextline, $nextref) = $self->shiftline();
     }

--- a/lib/Locale/Po4a/Text.pm
+++ b/lib/Locale/Po4a/Text.pm
@@ -535,10 +535,10 @@ sub parse_markdown_yaml_front_matter {
         $yfm .= $nextline;
         ($nextline, $nextref) = $self->shiftline();
     }
-    die "Could not get the YAML front matter from the file." if (length($yfm)==0);
+    die "Could not get the YAML Front Matter from the file." if (length($yfm)==0);
     my $yamlarray = YAML::Tiny->read_string($yfm)
         || die "Couldn't read YAML Front Matter ($!)\n$yfm\n";
-    die "Empty YAML front matter" unless (length($yamlarray)>0);
+    die "Empty YAML Front Matter" unless (length($yamlarray)>0);
 
     my ($indent,$ctx) = (0, "");
     foreach my $cursor ( @$yamlarray ) {
@@ -550,7 +550,7 @@ sub parse_markdown_yaml_front_matter {
         # A scalar document
         } elsif ( ! ref $cursor ) {
             $self->pushline("---\n");
-            $self->pushline(format_scalar($self->translate($cursor, $blockref, "YAML header (scalar)", "wrap" => 0)));
+            $self->pushline(format_scalar($self->translate($cursor, $blockref, "YAML Front Matter (scalar)", "wrap" => 0)));
 
         # A list at the root
         } elsif ( ref $cursor eq 'ARRAY' ) {
@@ -609,7 +609,7 @@ sub parse_markdown_yaml_front_matter {
            my $header = ('  ' x $indent) . '- ';
            my $type = ref $el;
            if ( ! $type ) {
-               $self->pushline($header . format_scalar($self->translate($el, $blockref, "YAML header: $ctx", "wrap" => 0)). "\n");
+               $self->pushline($header . format_scalar($self->translate($el, $blockref, "YAML Front Matter: $ctx", "wrap" => 0)). "\n");
 
            } elsif ( $type eq 'ARRAY' ) {
                if ( @$el ) {
@@ -639,7 +639,7 @@ sub parse_markdown_yaml_front_matter {
             my $header = ('  ' x $indent) . format_scalar($name, 1). ":";
             my $type = ref $el;
             if ( ! $type ) {
-                $self->pushline($header . " ". format_scalar($self->translate($el, $blockref, "YAML header: $ctx$name", "wrap" => 0)). "\n");
+                $self->pushline($header . " ". format_scalar($self->translate($el, $blockref, "YAML Front Matter: $ctx$name", "wrap" => 0)). "\n");
 
             } elsif ( $type eq 'ARRAY' ) {
                 if ( @$el ) {

--- a/t/t-20-text/PandocYamlFrontMatter.po
+++ b/t/t-20-text/PandocYamlFrontMatter.po
@@ -16,13 +16,13 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: YAML header: author
+#. type: YAML Front Matter: author
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "test"
 msgstr "test"
 
-#. type: YAML header: include_newlines
+#. type: YAML Front Matter: include_newlines
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid ""
@@ -34,67 +34,67 @@ msgstr ""
 "ces trois lignes de poésie\n"
 "vont apparaître"
 
-#. type: YAML header: people hobbies 
+#. type: YAML Front Matter: people hobbies 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Amateur radio"
 msgstr "Radio amateur"
 
-#. type: YAML header: people hobbies 
+#. type: YAML Front Matter: people hobbies 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Pet adoption & fostering"
 msgstr ""
 
-#. type: YAML header: people hobbies 
+#. type: YAML Front Matter: people hobbies 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Puzzle"
 msgstr "Puzzle"
 
-#. type: YAML header: people job
+#. type: YAML Front Matter: people job
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Developer"
 msgstr "Developeur"
 
-#. type: YAML header: people name
+#. type: YAML Front Matter: people name
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "John D'vloper"
 msgstr "John D'vloper"
 
-#. type: YAML header: people hobbies 
+#. type: YAML Front Matter: people hobbies 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Ice skating"
 msgstr "Patin à glace"
 
-#. type: YAML header: people hobbies 
+#. type: YAML Front Matter: people hobbies 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Water polo"
 msgstr "Water polo"
 
-#. type: YAML header: people hobbies 
+#. type: YAML Front Matter: people hobbies 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Caving"
 msgstr "Spéléologie"
 
-#. type: YAML header: people name
+#. type: YAML Front Matter: people name
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Tabitha Bitumen"
 msgstr "Tabitha Bitumen"
 
-#. type: YAML header: tags 
+#. type: YAML Front Matter: tags 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "yaml"
 msgstr ""
 
-#. type: YAML header: tags 
+#. type: YAML Front Matter: tags 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "markdown"
@@ -106,7 +106,7 @@ msgstr ""
 msgid "YAML: does it fit in Markdown?"
 msgstr ""
 
-#. type: YAML header: wrappedtext
+#. type: YAML Front Matter: wrappedtext
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "this is really a single line of text despite appearances\n"

--- a/t/t-20-text/PandocYamlFrontMatter.pot
+++ b/t/t-20-text/PandocYamlFrontMatter.pot
@@ -16,13 +16,13 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: YAML header: author
+#. type: YAML Front Matter: author
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "test"
 msgstr ""
 
-#. type: YAML header: include_newlines
+#. type: YAML Front Matter: include_newlines
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid ""
@@ -31,67 +31,67 @@ msgid ""
 "lines of poetry\n"
 msgstr ""
 
-#. type: YAML header: people hobbies 
+#. type: YAML Front Matter: people hobbies 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Amateur radio"
 msgstr ""
 
-#. type: YAML header: people hobbies 
+#. type: YAML Front Matter: people hobbies 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Pet adoption & fostering"
 msgstr ""
 
-#. type: YAML header: people hobbies 
+#. type: YAML Front Matter: people hobbies 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Puzzle"
 msgstr ""
 
-#. type: YAML header: people job
+#. type: YAML Front Matter: people job
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Developer"
 msgstr ""
 
-#. type: YAML header: people name
+#. type: YAML Front Matter: people name
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "John D'vloper"
 msgstr ""
 
-#. type: YAML header: people hobbies 
+#. type: YAML Front Matter: people hobbies 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Ice skating"
 msgstr ""
 
-#. type: YAML header: people hobbies 
+#. type: YAML Front Matter: people hobbies 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Water polo"
 msgstr ""
 
-#. type: YAML header: people hobbies 
+#. type: YAML Front Matter: people hobbies 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Caving"
 msgstr ""
 
-#. type: YAML header: people name
+#. type: YAML Front Matter: people name
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Tabitha Bitumen"
 msgstr ""
 
-#. type: YAML header: tags 
+#. type: YAML Front Matter: tags 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "yaml"
 msgstr ""
 
-#. type: YAML header: tags 
+#. type: YAML Front Matter: tags 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "markdown"
@@ -103,7 +103,7 @@ msgstr ""
 msgid "YAML: does it fit in Markdown?"
 msgstr ""
 
-#. type: YAML header: wrappedtext
+#. type: YAML Front Matter: wrappedtext
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "this is really a single line of text despite appearances\n"

--- a/t/t-20-text/PandocYamlFrontMatter.trans.po
+++ b/t/t-20-text/PandocYamlFrontMatter.trans.po
@@ -16,13 +16,13 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: YAML header: author
+#. type: YAML Front Matter: author
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "test"
 msgstr "test"
 
-#. type: YAML header: include_newlines
+#. type: YAML Front Matter: include_newlines
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid ""
@@ -34,67 +34,67 @@ msgstr ""
 "ces trois lignes de poésie\n"
 "vont apparaître\n"
 
-#. type: YAML header: people hobbies 
+#. type: YAML Front Matter: people hobbies 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Amateur radio"
 msgstr "Radio amateur"
 
-#. type: YAML header: people hobbies 
+#. type: YAML Front Matter: people hobbies 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Pet adoption & fostering"
 msgstr ""
 
-#. type: YAML header: people hobbies 
+#. type: YAML Front Matter: people hobbies 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Puzzle"
 msgstr "Puzzle"
 
-#. type: YAML header: people job
+#. type: YAML Front Matter: people job
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Developer"
 msgstr "Developeur"
 
-#. type: YAML header: people name
+#. type: YAML Front Matter: people name
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "John D'vloper"
 msgstr "John D'vloper"
 
-#. type: YAML header: people hobbies 
+#. type: YAML Front Matter: people hobbies 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Ice skating"
 msgstr "Patin à glace"
 
-#. type: YAML header: people hobbies 
+#. type: YAML Front Matter: people hobbies 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Water polo"
 msgstr "Water polo"
 
-#. type: YAML header: people hobbies 
+#. type: YAML Front Matter: people hobbies 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Caving"
 msgstr "Spéléologie"
 
-#. type: YAML header: people name
+#. type: YAML Front Matter: people name
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "Tabitha Bitumen"
 msgstr "Tabitha Bitumen"
 
-#. type: YAML header: tags 
+#. type: YAML Front Matter: tags 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "yaml"
 msgstr "yaml"
 
-#. type: YAML header: tags 
+#. type: YAML Front Matter: tags 
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "markdown"
@@ -106,7 +106,7 @@ msgstr "markdown"
 msgid "YAML: does it fit in Markdown?"
 msgstr "YAML a-t-il sa place en Markdown?"
 
-#. type: YAML header: wrappedtext
+#. type: YAML Front Matter: wrappedtext
 #: t-20-text/PandocYamlFrontMatter.md:1
 #, no-wrap
 msgid "this is really a single line of text despite appearances\n"


### PR DESCRIPTION
Thanks to @mquinson's great work in 111e2281f92e3e39df0c768ba6b90d7a45aedc5e, po4a now supports Markdown with YAML Front Matter #196!  This pull request is a collection of small fixes to make things work smoothly with the standards. 

*  do not add trailing whitespace to YAML Front Matter PO comments
* YAML Front Matter is the widespread standard name for this block
* support YAML "end of document" tag 

More detail in the commit messages.