### PR TITLE
po4a: Use value of --master-language for the language of the generated POT file

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -32,6 +32,8 @@ po4a tool:
    (requires gettext >= 0.19 -- June 2014)
  * Use the value of --master-charset for the charset of the generated
    POT file.
+ * Use the value of --master-language for the language of the generated
+   POT file.
 
 Core:
  * Add a --wrap-po option to control how the po file is wrapped, and

--- a/lib/Locale/Po4a/Po.pm
+++ b/lib/Locale/Po4a/Po.pm
@@ -198,6 +198,7 @@ sub initialize {
     $self->{options}{'package-version'}= "VERSION";
     $self->{options}{'wrap-po'} = 76;
     $self->{options}{'pot-charset'} = "CHARSET";
+    $self->{options}{'pot-language'} = "";
     foreach my $opt (keys %$options) {
 #        print STDERR "$opt: ".(defined($options->{$opt})?$options->{$opt}:"(undef)")."\n";
         if ($options->{$opt}) {
@@ -248,7 +249,7 @@ sub initialize {
                                 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n".
                                 "Last-Translator: FULL NAME <EMAIL\@ADDRESS>\n".
                                 "Language-Team: LANGUAGE <LL\@li.org>\n".
-                                "Language: \n".
+                                "Language: ".$self->{options}{'pot-language'}."\n".
                                 "MIME-Version: 1.0\n".
                                 "Content-Type: text/plain; charset=".$self->{options}{'pot-charset'}."\n".
                                 "Content-Transfer-Encoding: 8bit\n");

--- a/po4a
+++ b/po4a
@@ -348,6 +348,11 @@ at least at 80% to get written.
 
 Show a short help message.
 
+=item B<-M>, B<--master-language>
+
+Language of the source files containing the documents to
+translate. Note that all master documents must use the same language.
+
 =item B<-M>, B<--master-charset>
 
 Charset of the files containing the documents to translate. Note that all
@@ -713,6 +718,7 @@ sub get_options {
         "no-backups"      => 0,
         "rm-backups"      => 0,
         "threshold"       => 80,
+	"mastlang"        => "",
         "mastchar"        => "",
         "locchar"         => "",
         "addchar"         => "",
@@ -734,6 +740,7 @@ sub get_options {
     GetOptions(
         'help|h'                => \$opts{"help"},
 
+        'master-language|M=s'   => \$opts{"mastlang"},
         'master-charset|M=s'    => \$opts{"mastchar"},
         'localized-charset|L=s' => \$opts{"locchar"},
         'addendum-charset|A=s'  => \$opts{"addchar"},
@@ -1281,6 +1288,7 @@ if ($update_pot_file) {
             $pot_options{$_} = $po4a_opts{$_};
         }
     }
+    $pot_options{'pot-language'} = $po4a_opts{"mastlang"};
     $pot_options{'pot-charset'} = $po4a_opts{"mastchar"};
     my $potfile=Locale::Po4a::Po->new(\%pot_options);
     chdir $po4a_opts{"calldir"}

--- a/t/t-05-config/test02.conf
+++ b/t/t-05-config/test02.conf
@@ -5,6 +5,7 @@
                             de:tmp/test02.de.po
 
 [po4a_langs] fr it de
+[options] opt:"--master-language=en_US"
 [options] opt:"--master-charset=UTF-8"
 
 [type:man] t-05-config/test02_man.1 $lang:tmp/test02_man.$lang.1 es:tmp/test02_man.es.1


### PR DESCRIPTION
This lets the `Language:` header be set in the .pot file to declare what the source string language is.  This is not required nor apparently common, but it doesn't break how _gettext_ works: https://lists.gnu.org/archive/html/bug-gettext/2020-04/msg00004.html