### PR TITLE
add gettext flag "markdown-text" for relevant entries

### DIFF
--- a/lib/Locale/Po4a/Po.pm
+++ b/lib/Locale/Po4a/Po.pm
@@ -137,7 +137,7 @@ use Time::Local;
 use Encode;
 use Config;
 
-my @known_flags = qw(wrap no-wrap c-format fuzzy);
+my @known_flags = qw(wrap no-wrap c-format markdown-text fuzzy);
 
 our %debug = (
     'canonize' => 0,

--- a/lib/Locale/Po4a/Text.pm
+++ b/lib/Locale/Po4a/Text.pm
@@ -770,7 +770,8 @@ sub parse_markdown {
 
         # Remove the trailing newline from the title
         chomp($paragraph);
-        my $t = $self->translate( $paragraph, $self->{ref}, "Title $level", "wrap" => 0 );
+        my $t = $self->translate( $paragraph, $self->{ref}, "Title $level", "wrap" => 0,
+				  "flags" => "markdown-text" );
 
         # Add the newline again for the output
         $self->pushline( $t . "\n" );
@@ -787,7 +788,8 @@ sub parse_markdown {
         do_paragraph( $self, $paragraph, $wrapped_mode );
         $wrapped_mode = 0;
         $paragraph    = "";
-        my $t = $self->translate( $title, $self->{ref}, "Title $titlelevel1", "wrap" => 0 );
+        my $t = $self->translate( $title, $self->{ref}, "Title $titlelevel1", "wrap" => 0,
+				  "flags" => "markdown-text" );
         $self->pushline( $titlelevel1 . $titlespaces . $t . $titlelevel2 . "\n" );
         $wrapped_mode = $defaultwrap;
     } elsif ( $line =~ /^[ ]{0,3}([*_-])\s*(?:\1\s*){2,}$/ ) {
@@ -917,6 +919,11 @@ sub parse {
 sub do_paragraph {
     my ( $self, $paragraph, $wrap ) = ( shift, shift, shift );
     my $type = shift || $self->{type} || "Plain text";
+    my $flags = "";
+    if ($type eq "Plain text" and $markdown) {
+	$flags = "markdown-text";
+    }
+
     return if ( $paragraph eq "" );
 
     $wrap = 0 unless $defaultwrap;
@@ -963,6 +970,7 @@ sub do_paragraph {
                         $text,
                         $self->{ref},
                         "Bullet: '$indent1$bullet'",
+                        "flags" => "markdown-text",
                         "wrap"    => $defaultwrap,
                         "wrapcol" => -( length $indent2 )
                     );
@@ -992,6 +1000,7 @@ sub do_paragraph {
         $self->{ref},
         $type,
         "comment" => join( "\n", @comments ),
+        "flags"   => $flags,
         "wrap"    => $wrap
     );
     @comments = ();

--- a/lib/Locale/Po4a/TransTractor.pm
+++ b/lib/Locale/Po4a/TransTractor.pm
@@ -997,6 +997,7 @@ sub translate {
         'reference' => $ref,
         'type'      => $type,
         'automatic' => $options{'comment'},
+        'flags'     => $options{'flags'},
         'wrap'      => $options{'wrap'} || 0,
         'wrapcol'   => $options{'wrapcol'}
     );

--- a/t/t-20-text/MarkDown.pot
+++ b/t/t-20-text/MarkDown.pot
@@ -35,27 +35,31 @@ msgstr ""
 
 #. type: Title =
 #: t-20-text/MarkDown.md:5
-#, no-wrap
+#, markdown-text, no-wrap
 msgid "A nice title"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDown.md:8
+#, markdown-text
 msgid "The first paragraph."
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDown.md:10
+#, markdown-text
 msgid "The second paragraph."
 msgstr ""
 
 #. type: Bullet: ' * '
 #: t-20-text/MarkDown.md:15
+#, markdown-text
 msgid "Some bullet point"
 msgstr ""
 
 #. type: Bullet: ' * '
 #: t-20-text/MarkDown.md:15
+#, markdown-text
 msgid ""
 "Another bullet point with a second line, which is so long that it should get "
 "wrapped by the output of po4a"
@@ -63,22 +67,24 @@ msgstr ""
 
 #. type: Bullet: ' * '
 #: t-20-text/MarkDown.md:15
+#, markdown-text
 msgid "A third bullet point"
 msgstr ""
 
 #. type: Title #
 #: t-20-text/MarkDown.md:16
-#, no-wrap
+#, markdown-text, no-wrap
 msgid "Another title with different markup"
 msgstr ""
 
 #. type: Title ##
 #: t-20-text/MarkDown.md:18
-#, no-wrap
+#, markdown-text, no-wrap
 msgid "Subtitle"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDown.md:20
+#, markdown-text
 msgid "And more text in a paragraph."
 msgstr ""

--- a/t/t-20-text/MarkDownNestedLists.pot
+++ b/t/t-20-text/MarkDownNestedLists.pot
@@ -18,30 +18,36 @@ msgstr ""
 
 #. type: Plain text
 #: MarkDownNestedLists.md:1
+#, markdown-text
 msgid "This serves as testcase for nested lists."
 msgstr ""
 
 #. type: Bullet: ' * '
 #: MarkDownNestedLists.md:3
+#, markdown-text
 msgid "Item 1"
 msgstr ""
 
 #. type: Bullet: ' * '
 #: MarkDownNestedLists.md:4
+#, markdown-text
 msgid "Item 2"
 msgstr ""
 
 #. type: Bullet: ' * '
 #: MarkDownNestedLists.md:5
+#, markdown-text
 msgid "Nested item 1"
 msgstr ""
 
 #. type: Bullet: ' * '
 #: MarkDownNestedLists.md:6
+#, markdown-text
 msgid "Nested item 2"
 msgstr ""
 
 #. type: Plain text
 #: MarkDownNestedLists.md:8
+#, markdown-text
 msgid "Normal paragraph."
 msgstr ""

--- a/t/t-20-text/MarkDownNoWrap.pot
+++ b/t/t-20-text/MarkDownNoWrap.pot
@@ -18,13 +18,13 @@ msgstr ""
 
 #. type: Title #
 #: t-20-text/MarkDownNoWrap.md:2
-#, no-wrap
+#, markdown-text, no-wrap
 msgid "All About Descriptions, Graphics, and Screenshots"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownNoWrap.md:10
-#, no-wrap
+#, markdown-text, no-wrap
 msgid ""
 "Each app can have complete app store content, including localized descriptions,\n"
 "feature graphics, and screenshots (as of v0.103 of the F-Droid client app and\n"
@@ -36,7 +36,7 @@ msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownNoWrap.md:14
-#, no-wrap
+#, markdown-text, no-wrap
 msgid ""
 "* Do not remove this line (it will not be displayed)\n"
 "{:toc}\n"

--- a/t/t-20-text/MarkDownRules.pot
+++ b/t/t-20-text/MarkDownRules.pot
@@ -18,12 +18,13 @@ msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:2
+#, markdown-text
 msgid "Here are three horisontal rules / thematic breaks:"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:8
-#, no-wrap
+#, markdown-text, no-wrap
 msgid ""
 "This is a paragraph\n"
 "+++\n"
@@ -33,7 +34,7 @@ msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:10
-#, no-wrap
+#, markdown-text, no-wrap
 msgid ""
 "and continues\n"
 "--\n"
@@ -41,7 +42,7 @@ msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:12
-#, no-wrap
+#, markdown-text, no-wrap
 msgid ""
 "**\n"
 "__\n"
@@ -49,33 +50,37 @@ msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:14
+#, markdown-text
 msgid "until here"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:16
+#, markdown-text
 msgid "Here are three more rules:"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:20
+#, markdown-text
 msgid "but this is code:"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:22
-#, no-wrap
+#, markdown-text, no-wrap
 msgid "    ***\n"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:24
+#, markdown-text
 msgid "and this is a paragraph:"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:27
-#, no-wrap
+#, markdown-text, no-wrap
 msgid ""
 "Foo\n"
 "    ***\n"
@@ -83,81 +88,96 @@ msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:29
+#, markdown-text
 msgid "here are 5 rules:"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:35
+#, markdown-text
 msgid "but these are not rules:"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:37
+#, markdown-text
 msgid "_ _ _ _ a"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:39
+#, markdown-text
 msgid "a------"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:41
+#, markdown-text
 msgid "---a---"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:43
-#, no-wrap
+#, markdown-text, no-wrap
 msgid " *-*\n"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:45 t-20-text/MarkDownRules.md:51
+#, markdown-text
 msgid "Below is an interrupting rule:"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:47
+#, markdown-text
 msgid "- foo"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:49
+#, markdown-text
 msgid "- bar"
 msgstr ""
 
 #. type: Bullet: '* '
 #: t-20-text/MarkDownRules.md:53 t-20-text/MarkDownRules.md:59 t-20-text/MarkDownRules.md:65
+#, markdown-text
 msgid "Foo"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:55 t-20-text/MarkDownRules.md:61
+#, markdown-text
 msgid "bar"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:57
+#, markdown-text
 msgid "But this is a header:"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:63
+#, markdown-text
 msgid "This is interrupted by rule:"
 msgstr ""
 
 #. type: Bullet: '* '
 #: t-20-text/MarkDownRules.md:67
+#, markdown-text
 msgid "Bar"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:69
+#, markdown-text
 msgid "This is a list:"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownRules.md:71
+#, markdown-text
 msgid "- Foo - * * *"
 msgstr ""

--- a/t/t-20-text/MarkDownYamlFrontMatter.pot
+++ b/t/t-20-text/MarkDownYamlFrontMatter.pot
@@ -99,7 +99,7 @@ msgstr ""
 
 #. type: Title #
 #: t-20-text/PandocYamlFrontMatter.md:1 t-20-text/PandocYamlFrontMatter.md:32
-#, no-wrap
+#, markdown-text, no-wrap
 msgid "YAML: does it fit in Markdown?"
 msgstr ""
 
@@ -111,6 +111,7 @@ msgstr ""
 
 #. type: Plain text
 #: t-20-text/PandocYamlFrontMatter.md:36
+#, markdown-text
 msgid ""
 "Lots of Static Site Generators like Jekyll, Hugo, Lektor and more use a "
 "standard format: Markdown with YAML Front Matter."
@@ -118,10 +119,12 @@ msgstr ""
 
 #. type: Plain text
 #: t-20-text/PandocYamlFrontMatter.md:38
+#, markdown-text
 msgid "Why"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/PandocYamlFrontMatter.md:41
+#, markdown-text
 msgid "Because blog posts need metadata!"
 msgstr ""

--- a/t/t-20-text/MarkDownYamlFrontMatter.trans.po
+++ b/t/t-20-text/MarkDownYamlFrontMatter.trans.po
@@ -102,7 +102,7 @@ msgstr "markdown"
 
 #. type: Title #
 #: t-20-text/PandocYamlFrontMatter.md:1 t-20-text/PandocYamlFrontMatter.md:32
-#, no-wrap
+#, markdown-text, no-wrap
 msgid "YAML: does it fit in Markdown?"
 msgstr "YAML a-t-il sa place en Markdown?"
 
@@ -121,10 +121,12 @@ msgstr "De nombreux générateurs de sites comme Jekyll, Hugo, Lektor et d'autre
 
 #. type: Plain text
 #: t-20-text/PandocYamlFrontMatter.md:38
+#, markdown-text
 msgid "Why"
 msgstr "Pourquoi"
 
 #. type: Plain text
 #: t-20-text/PandocYamlFrontMatter.md:41
+#, markdown-text
 msgid "Because blog posts need metadata!"
 msgstr "Parce que les posts de blog ont besoin de metadata!"

--- a/t/t-20-text/MarkDownYamlFrontMatterOptions.pot
+++ b/t/t-20-text/MarkDownYamlFrontMatterOptions.pot
@@ -36,12 +36,13 @@ msgstr ""
 
 #. type: Title #
 #: t-20-text/MarkDownYamlFrontMatterOptions.md:1 t-20-text/MarkDownYamlFrontMatterOptions.md:27
-#, no-wrap
+#, markdown-text, no-wrap
 msgid "YAML: does it fit in Markdown?"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownYamlFrontMatterOptions.md:31
+#, markdown-text
 msgid ""
 "Lots of Static Site Generators like Jekyll, Hugo, Lektor and more use a "
 "standard format: Markdown with YAML Front Matter."
@@ -49,10 +50,12 @@ msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownYamlFrontMatterOptions.md:33
+#, markdown-text
 msgid "Why"
 msgstr ""
 
 #. type: Plain text
 #: t-20-text/MarkDownYamlFrontMatterOptions.md:36
+#, markdown-text
 msgid "Because blog posts need metadata!"
 msgstr ""

--- a/t/t-20-text/PandocHeaderMultipleLines.pot
+++ b/t/t-20-text/PandocHeaderMultipleLines.pot
@@ -38,5 +38,6 @@ msgstr ""
 
 #. type: Plain text
 #: t-20-text/PandocHeaderMultipleLines.md:9
+#, markdown-text
 msgid "Other text."
 msgstr ""

--- a/t/t-20-text/PandocMultipleAuthors.pot
+++ b/t/t-20-text/PandocMultipleAuthors.pot
@@ -35,5 +35,6 @@ msgstr ""
 
 #. type: Plain text
 #: t-20-text/PandocMultipleAuthors.md:5
+#, markdown-text
 msgid "Other text."
 msgstr ""

--- a/t/t-20-text/PandocOnlyAuthor.pot
+++ b/t/t-20-text/PandocOnlyAuthor.pot
@@ -24,5 +24,6 @@ msgstr ""
 
 #. type: Plain text
 #: t-20-text/PandocOnlyAuthor.md:4
+#, markdown-text
 msgid "Other text."
 msgstr ""

--- a/t/t-20-text/PandocOnlyTitle.pot
+++ b/t/t-20-text/PandocOnlyTitle.pot
@@ -23,5 +23,6 @@ msgstr ""
 
 #. type: Plain text
 #: t-20-text/PandocOnlyTitle.md:3
+#, markdown-text
 msgid "Other text."
 msgstr ""

--- a/t/t-20-text/PandocTitleAndDate.pot
+++ b/t/t-20-text/PandocTitleAndDate.pot
@@ -29,5 +29,6 @@ msgstr ""
 
 #. type: Plain text
 #: t-20-text/PandocTitleAndDate.md:5
+#, markdown-text
 msgid "Other text."
 msgstr ""

--- a/t/t-20-text/PandocTitleAuthors.pot
+++ b/t/t-20-text/PandocTitleAuthors.pot
@@ -41,5 +41,6 @@ msgstr ""
 
 #. type: Plain text
 #: t-20-text/PandocTitleAuthors.md:9
+#, markdown-text
 msgid "Other text."
 msgstr ""


### PR DESCRIPTION
_gettext_ defines many flags for various entries that need special handling: https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html  Markdown text is such a thing.  Translation tools like Weblate will automatically enable certain checks and displays based on the _gettext_ flags.  This change defines a new flag `markdown-text` to make all text entries that can have Markdown syntax in them.

(FYI, Weblate currently uses `md-text` but we're adding `markdown-text` since much less ambiguous.  The built-in _gettext_ flags do not use abbreviations.  Follow that here https://github.com/WeblateOrg/weblate/issues/3648)