### PR TITLE
asciidoc: accept lines beginning 3 dots as numbered list items

### DIFF
--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -697,7 +697,7 @@ sub parse {
             $self->pushline(".$t\n");
             @comments = ();
         } elsif ( not defined $self->{verbatim}
-            and ( $line =~ m/^(\s*)((?:[-*o+]+|(?:[0-9]+[.\)])|(?:[a-z][.\)])|\([0-9]+\)|\.|\.\.)\s+)(.*)$/ ) )
+            and ( $line =~ m/^(\s*)((?:[-*o+]+|(?:[0-9]+[.\)])|(?:[a-z][.\)])|\([0-9]+\)|\.{1,3})\s+)(.*)$/ ) )
         {
             my $indent = $1 || "";
             my $bullet = $2;

--- a/t/t-03-asciidoc/Lists.asciidoc
+++ b/t/t-03-asciidoc/Lists.asciidoc
@@ -13,6 +13,7 @@ spans over several lines (missing leading indent)
 1. Integer numbered list item with optional numbering.
 .. Lowercase letter numbered list item.
 a. Lowercase letter numbered list item with optional numbering.
+... Third level of numbered list.
 
 - Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
   * Fusce euismod commodo velit.

--- a/t/t-03-asciidoc/Lists.out
+++ b/t/t-03-asciidoc/Lists.out
@@ -12,6 +12,7 @@ Bulleted and Numbered Lists
 1. Integer numbered list item with optional numbering.
 .. Lowercase letter numbered list item.
 a. Lowercase letter numbered list item with optional numbering.
+... Third level of numbered list.
 
 - Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
   * Fusce euismod commodo velit.

--- a/t/t-03-asciidoc/Lists.pot
+++ b/t/t-03-asciidoc/Lists.pot
@@ -59,247 +59,252 @@ msgid "Lowercase letter numbered list item with optional numbering."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:18
+#: t-03-asciidoc/Lists.asciidoc:17
+msgid "Third level of numbered list."
+msgstr ""
+
+#. type: Plain text
+#: t-03-asciidoc/Lists.asciidoc:19
 msgid "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:19 t-03-asciidoc/Lists.asciidoc:26 t-03-asciidoc/Lists.asciidoc:28 t-03-asciidoc/Lists.asciidoc:32 t-03-asciidoc/Lists.asciidoc:33 t-03-asciidoc/Lists.asciidoc:51 t-03-asciidoc/Lists.asciidoc:53
+#: t-03-asciidoc/Lists.asciidoc:20 t-03-asciidoc/Lists.asciidoc:27 t-03-asciidoc/Lists.asciidoc:29 t-03-asciidoc/Lists.asciidoc:33 t-03-asciidoc/Lists.asciidoc:34 t-03-asciidoc/Lists.asciidoc:52 t-03-asciidoc/Lists.asciidoc:54
 msgid "Fusce euismod commodo velit."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:22
+#: t-03-asciidoc/Lists.asciidoc:23
 msgid ""
 "Qui in magna commodo, est labitur dolorum an. Est ne magna primis "
 "adolescens. Sit munere ponderum dignissim et. Minim luptatum et vel."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:23 t-03-asciidoc/Lists.asciidoc:27 t-03-asciidoc/Lists.asciidoc:29 t-03-asciidoc/Lists.asciidoc:34 t-03-asciidoc/Lists.asciidoc:36 t-03-asciidoc/Lists.asciidoc:56 t-03-asciidoc/Lists.asciidoc:57 t-03-asciidoc/Lists.asciidoc:105 t-03-asciidoc/Lists.asciidoc:106 t-03-asciidoc/Lists.asciidoc:110
+#: t-03-asciidoc/Lists.asciidoc:24 t-03-asciidoc/Lists.asciidoc:28 t-03-asciidoc/Lists.asciidoc:30 t-03-asciidoc/Lists.asciidoc:35 t-03-asciidoc/Lists.asciidoc:37 t-03-asciidoc/Lists.asciidoc:57 t-03-asciidoc/Lists.asciidoc:58 t-03-asciidoc/Lists.asciidoc:106 t-03-asciidoc/Lists.asciidoc:107 t-03-asciidoc/Lists.asciidoc:111
 msgid "Vivamus fringilla mi eu lacus."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:24 t-03-asciidoc/Lists.asciidoc:30 t-03-asciidoc/Lists.asciidoc:35 t-03-asciidoc/Lists.asciidoc:37 t-03-asciidoc/Lists.asciidoc:58 t-03-asciidoc/Lists.asciidoc:60 t-03-asciidoc/Lists.asciidoc:107 t-03-asciidoc/Lists.asciidoc:111
+#: t-03-asciidoc/Lists.asciidoc:25 t-03-asciidoc/Lists.asciidoc:31 t-03-asciidoc/Lists.asciidoc:36 t-03-asciidoc/Lists.asciidoc:38 t-03-asciidoc/Lists.asciidoc:59 t-03-asciidoc/Lists.asciidoc:61 t-03-asciidoc/Lists.asciidoc:108 t-03-asciidoc/Lists.asciidoc:112
 msgid "Donec eget arcu bibendum nunc consequat lobortis."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:25
+#: t-03-asciidoc/Lists.asciidoc:26
 msgid "Nulla porttitor vulputate libero."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:31
+#: t-03-asciidoc/Lists.asciidoc:32
 msgid "Praesent eget purus quis magna eleifend eleifend."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:38
+#: t-03-asciidoc/Lists.asciidoc:39
 msgid "Nam fermentum mattis ante."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:40
+#: t-03-asciidoc/Lists.asciidoc:41
 msgid "List Item 1"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:41
+#: t-03-asciidoc/Lists.asciidoc:42
 msgid "Non-indented new list Item"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:42
+#: t-03-asciidoc/Lists.asciidoc:43
 msgid "Another Item"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:43
+#: t-03-asciidoc/Lists.asciidoc:44
 msgid "List Item 2"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:44
+#: t-03-asciidoc/Lists.asciidoc:45
 msgid "List Item 3"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:45
+#: t-03-asciidoc/Lists.asciidoc:46
 msgid "Non-indented new list Item 2"
 msgstr ""
 
 #. type: Title -
-#: t-03-asciidoc/Lists.asciidoc:47
+#: t-03-asciidoc/Lists.asciidoc:48
 #, no-wrap
 msgid "Vertical Labeled Lists"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:49
+#: t-03-asciidoc/Lists.asciidoc:50
 #, no-wrap
 msgid "Lorem"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:54
+#: t-03-asciidoc/Lists.asciidoc:55
 #, no-wrap
 msgid "Ipsum"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:58
+#: t-03-asciidoc/Lists.asciidoc:59
 #, no-wrap
 msgid "Dolor"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:60
+#: t-03-asciidoc/Lists.asciidoc:61
 #, no-wrap
 msgid "Suspendisse"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:62
+#: t-03-asciidoc/Lists.asciidoc:63
 #, no-wrap
 msgid "A massa id sem aliquam auctor.\n"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:62
+#: t-03-asciidoc/Lists.asciidoc:63
 #, no-wrap
 msgid "Morbi"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:64
+#: t-03-asciidoc/Lists.asciidoc:65
 #, no-wrap
 msgid "Pretium nulla vel lorem.\n"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:64
+#: t-03-asciidoc/Lists.asciidoc:66
 #, no-wrap
 msgid "In"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:66
+#: t-03-asciidoc/Lists.asciidoc:67
 #, no-wrap
 msgid "Dictum mauris in urna.\n"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:67
+#: t-03-asciidoc/Lists.asciidoc:68
 #, no-wrap
 msgid "<pathspec>..."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:70
+#: t-03-asciidoc/Lists.asciidoc:71
 msgid ""
 "Files to add content from.  Fileglobs (e.g. `*.c`) can be given to add all "
 "matching files."
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:71
+#: t-03-asciidoc/Lists.asciidoc:72
 #, no-wrap
 msgid "-n"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:72
+#: t-03-asciidoc/Lists.asciidoc:73
 #, no-wrap
 msgid "--dry-run"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:75
+#: t-03-asciidoc/Lists.asciidoc:74
 msgid ""
 "Don't actually add the file(s), just show if they exist and/or will be "
 "ignored."
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:76
+#: t-03-asciidoc/Lists.asciidoc:77
 #, no-wrap
 msgid "\\--"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:80
+#: t-03-asciidoc/Lists.asciidoc:81
 msgid ""
 "This option can be used to separate command-line options from the list of "
 "files, (useful when filenames might be mistaken for command-line options)."
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:81
+#: t-03-asciidoc/Lists.asciidoc:82
 #, no-wrap
 msgid "[<refname>...]"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:84
+#: t-03-asciidoc/Lists.asciidoc:85
 msgid "A list of references used to limit the references reported as available."
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:85
+#: t-03-asciidoc/Lists.asciidoc:86
 #, no-wrap
 msgid "$(prefix)/etc/gitconfig"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:87
+#: t-03-asciidoc/Lists.asciidoc:88
 msgid "System-wide configuration file."
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:88
+#: t-03-asciidoc/Lists.asciidoc:89
 #, no-wrap
 msgid "~/.gitconfig"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:91
+#: t-03-asciidoc/Lists.asciidoc:92
 msgid "User-specific configuration file. Also called \"global\" configuration file."
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:92
+#: t-03-asciidoc/Lists.asciidoc:93
 #, no-wrap
 msgid "%G"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:94
+#: t-03-asciidoc/Lists.asciidoc:95
 msgid "Git directory name"
 msgstr ""
 
 #. type: Title -
-#: t-03-asciidoc/Lists.asciidoc:96
+#: t-03-asciidoc/Lists.asciidoc:97
 #, no-wrap
 msgid "Horizontal Labeled Lists"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:98
+#: t-03-asciidoc/Lists.asciidoc:99
 #, no-wrap
 msgid "*Lorem*"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:100
+#: t-03-asciidoc/Lists.asciidoc:101
 msgid ""
 "Fusce euismod commodo velit.  Qui in magna commodo, est labitur dolorum "
 "an. Est ne magna primis adolescens."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:103
+#: t-03-asciidoc/Lists.asciidoc:104
 #, no-wrap
 msgid ""
 "  Fusce euismod commodo velit.\n"
@@ -307,131 +312,131 @@ msgid ""
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:104
+#: t-03-asciidoc/Lists.asciidoc:105
 #, no-wrap
 msgid "*Ipsum*"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:108
+#: t-03-asciidoc/Lists.asciidoc:109
 #, no-wrap
 msgid "*Dolor*"
 msgstr ""
 
 #. type: Title -
-#: t-03-asciidoc/Lists.asciidoc:113
+#: t-03-asciidoc/Lists.asciidoc:114
 #, no-wrap
 msgid "Question and Answer Lists"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:114
+#: t-03-asciidoc/Lists.asciidoc:115
 #, no-wrap
 msgid "Question one"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:116
+#: t-03-asciidoc/Lists.asciidoc:117
 msgid "Answer one."
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:116
+#: t-03-asciidoc/Lists.asciidoc:117
 #, no-wrap
 msgid "Question two"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:118
+#: t-03-asciidoc/Lists.asciidoc:119
 msgid "Answer two."
 msgstr ""
 
 #. type: Title -
-#: t-03-asciidoc/Lists.asciidoc:120
+#: t-03-asciidoc/Lists.asciidoc:121
 #, no-wrap
 msgid "Glossary Lists"
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:122
+#: t-03-asciidoc/Lists.asciidoc:123
 #, no-wrap
 msgid "A glossary term"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:124 t-03-asciidoc/Lists.asciidoc:126
+#: t-03-asciidoc/Lists.asciidoc:125 t-03-asciidoc/Lists.asciidoc:127
 msgid "The corresponding definition."
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:124
+#: t-03-asciidoc/Lists.asciidoc:125
 #, no-wrap
 msgid "A second glossary term"
 msgstr ""
 
 #. type: Title -
-#: t-03-asciidoc/Lists.asciidoc:128
+#: t-03-asciidoc/Lists.asciidoc:129
 #, no-wrap
 msgid "Bibliography Lists"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:132 t-03-asciidoc/Lists.asciidoc:142
+#: t-03-asciidoc/Lists.asciidoc:133 t-03-asciidoc/Lists.asciidoc:143
 msgid ""
 "[[[taoup]]] Eric Steven Raymond. 'The Art of UNIX "
 "Programming'. Addison-Wesley. ISBN 0-13-142901-9."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:134
+#: t-03-asciidoc/Lists.asciidoc:135
 msgid ""
 "[[[walsh-muellner]]] Norman Walsh & Leonard Muellner.  'DocBook - The "
 "Definitive Guide'. O'Reilly & Associates."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:135
+#: t-03-asciidoc/Lists.asciidoc:136
 msgid "ISBN 1-56592-580-7."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:137
+#: t-03-asciidoc/Lists.asciidoc:138
 msgid "The same in a bibliography section, and without the doc typo"
 msgstr ""
 
 #. type: Title -
-#: t-03-asciidoc/Lists.asciidoc:139
+#: t-03-asciidoc/Lists.asciidoc:140
 #, no-wrap
 msgid "Bibliography"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:145
+#: t-03-asciidoc/Lists.asciidoc:146
 msgid ""
 "[[[walsh-muellner]]] Norman Walsh & Leonard Muellner.  'DocBook - The "
 "Definitive Guide'. O'Reilly & Associates. 1999.  ISBN 1-56592-580-7."
 msgstr ""
 
 #. type: Title -
-#: t-03-asciidoc/Lists.asciidoc:147
+#: t-03-asciidoc/Lists.asciidoc:148
 #, no-wrap
 msgid "List Item Continuation"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:150 t-03-asciidoc/Lists.asciidoc:181
+#: t-03-asciidoc/Lists.asciidoc:151 t-03-asciidoc/Lists.asciidoc:182
 msgid "List item one."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:153
+#: t-03-asciidoc/Lists.asciidoc:154
 msgid ""
 "List item one continued with a second paragraph followed by an Indented "
 "block."
 msgstr ""
 
 #. type: delimited block .
-#: t-03-asciidoc/Lists.asciidoc:157
+#: t-03-asciidoc/Lists.asciidoc:158
 #, no-wrap
 msgid ""
 "$ ls *.sh\n"
@@ -439,17 +444,17 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:160
+#: t-03-asciidoc/Lists.asciidoc:161
 msgid "List item one continued with a third paragraph."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:162
+#: t-03-asciidoc/Lists.asciidoc:163
 msgid "List item two."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:165
+#: t-03-asciidoc/Lists.asciidoc:166
 #, no-wrap
 msgid ""
 "List item two literal paragraph (no continuation required).\n"
@@ -457,12 +462,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:167
+#: t-03-asciidoc/Lists.asciidoc:168
 msgid "Nested list (item one)."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:170
+#: t-03-asciidoc/Lists.asciidoc:171
 #, no-wrap
 msgid ""
 "Nested list literal paragraph (no continuation required).\n"
@@ -470,76 +475,76 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:172
+#: t-03-asciidoc/Lists.asciidoc:173
 msgid "Nested list appended list item one paragraph"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:174
+#: t-03-asciidoc/Lists.asciidoc:175
 msgid "Nested list item two."
 msgstr ""
 
 #. type: Title -
-#: t-03-asciidoc/Lists.asciidoc:177
+#: t-03-asciidoc/Lists.asciidoc:178
 #, no-wrap
 msgid "List Block"
 msgstr ""
 
 #. type: Block title
-#: t-03-asciidoc/Lists.asciidoc:179
+#: t-03-asciidoc/Lists.asciidoc:180
 #, no-wrap
 msgid "Nested List Block"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:183 t-03-asciidoc/Lists.asciidoc:188
+#: t-03-asciidoc/Lists.asciidoc:184 t-03-asciidoc/Lists.asciidoc:189
 msgid "This paragraph is part of the preceding list item"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:186
+#: t-03-asciidoc/Lists.asciidoc:187
 msgid "This list is nested and does not require explicit item continuation."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:190
+#: t-03-asciidoc/Lists.asciidoc:191
 msgid "List item b."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:192
+#: t-03-asciidoc/Lists.asciidoc:193
 msgid "This paragraph belongs to list item b."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:195
+#: t-03-asciidoc/Lists.asciidoc:196
 msgid "This paragraph belongs to item 1."
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:197
+#: t-03-asciidoc/Lists.asciidoc:198
 msgid "Item 2 of the outer list."
 msgstr ""
 
 #. type: Block title
-#: t-03-asciidoc/Lists.asciidoc:198
+#: t-03-asciidoc/Lists.asciidoc:199
 #, no-wrap
 msgid "Literal Paragraph in a Vertical Labeled Lists"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:201
+#: t-03-asciidoc/Lists.asciidoc:202
 msgid "This comes from the git doc, on which po4a used to fail miserably."
 msgstr ""
 
 #. type: Labeled list
-#: t-03-asciidoc/Lists.asciidoc:202
+#: t-03-asciidoc/Lists.asciidoc:203
 #, no-wrap
 msgid "patch"
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:209
+#: t-03-asciidoc/Lists.asciidoc:210
 msgid ""
 "This lets you choose one path out of a 'status' like selection.  After "
 "choosing the path, it presents the diff between the index and the working "
@@ -548,7 +553,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:224
+#: t-03-asciidoc/Lists.asciidoc:225
 #, no-wrap
 msgid ""
 "y - stage this hunk\n"
@@ -568,7 +573,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: t-03-asciidoc/Lists.asciidoc:226
+#: t-03-asciidoc/Lists.asciidoc:227
 msgid ""
 "After deciding the fate for all hunks, if there is any hunk that was chosen, "
 "the index is updated with the selected hunks."


### PR DESCRIPTION
This is accepted in the specification of asciidoc.

fixes #210