### PR TITLE
asciidoc: accept nested number list of any depth

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,7 +9,8 @@ __   __/ _ \ | ___| ( _ )
   \_/  \___(_)____/ \___/      (not released yet)
 
 AsciiDoc:
- * Accept numbered list items beginning with three dots (GitHub's #210)
+ * Accept numbered list items beginning with any number of dots
+   (GitHub's #210)
 
 Markdown:
  * Avoid translating Markdown fenced code block info string (GitHub's #194)

--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -697,7 +697,7 @@ sub parse {
             $self->pushline(".$t\n");
             @comments = ();
         } elsif ( not defined $self->{verbatim}
-            and ( $line =~ m/^(\s*)((?:[-*o+]+|(?:[0-9]+[.\)])|(?:[a-z][.\)])|\([0-9]+\)|\.{1,3})\s+)(.*)$/ ) )
+            and ( $line =~ m/^(\s*)((?:[-*o+\.]+|(?:[0-9]+[.\)])|(?:[a-z][.\)])|\([0-9]+\))\s+)(.*)$/ ) )
         {
             my $indent = $1 || "";
             my $bullet = $2;

--- a/t/t-03-asciidoc/Lists.asciidoc
+++ b/t/t-03-asciidoc/Lists.asciidoc
@@ -225,3 +225,9 @@ patch::
 +
 After deciding the fate for all hunks, if there is any hunk
 that was chosen, the index is updated with the selected hunks.
+
+. First level
+.. Second level
+... Third level
+.... Fourth level
+..... Fifth level

--- a/t/t-03-asciidoc/Lists.out
+++ b/t/t-03-asciidoc/Lists.out
@@ -218,3 +218,9 @@ patch::
 +
 After deciding the fate for all hunks, if there is any hunk that was chosen,
 the index is updated with the selected hunks.
+
+. First level
+.. Second level
+... Third level
+.... Fourth level
+..... Fifth level

--- a/t/t-03-asciidoc/Lists.pot
+++ b/t/t-03-asciidoc/Lists.pot
@@ -578,3 +578,28 @@ msgid ""
 "After deciding the fate for all hunks, if there is any hunk that was chosen, "
 "the index is updated with the selected hunks."
 msgstr ""
+
+#. type: Plain text
+#: t-03-asciidoc/Lists.asciidoc:230
+msgid "First level"
+msgstr ""
+
+#. type: Plain text
+#: t-03-asciidoc/Lists.asciidoc:231
+msgid "Second level"
+msgstr ""
+
+#. type: Plain text
+#: t-03-asciidoc/Lists.asciidoc:232
+msgid "Third level"
+msgstr ""
+
+#. type: Plain text
+#: t-03-asciidoc/Lists.asciidoc:233
+msgid "Fourth level"
+msgstr ""
+
+#. type: Plain text
+#: t-03-asciidoc/Lists.asciidoc:233
+msgid "Fifth level"
+msgstr ""


### PR DESCRIPTION
The limitation to 5 levels has been lifted in
https://github.com/asciidoctor/asciidoctor/issues/2854