### PR TITLE
asciidoc: correctly manage empty lines in tables

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,7 @@ Documentation:
 Tests:
  * Also ignore 'Project-Id-Version' when diffing PO files (GitHub's #224)
  * asciidoc: reactivate tablecells tests
+ * asciidoc: fix management of images in tables (Github's #226)
 
 Translations:
  * Updated: German, thanks Helge Kreutzmann.

--- a/t/fmt-asciidoc.t
+++ b/t/fmt-asciidoc.t
@@ -12,18 +12,13 @@ use Testhelper;
 my @tests;
 
 foreach my $t (
-    qw(Titles BlockTitles BlockId Paragraphs DelimitedBlocks Lists Footnotes Callouts Comments Tables Attributes StyleMacro)
+    qw(Titles BlockTitles BlockId Paragraphs DelimitedBlocks Lists Footnotes Callouts Comments Tables TablesImageText Attributes StyleMacro)
   )
 {
     push @tests, { 'format' => 'asciidoc', 'input' => "fmt/asciidoc/$t.adoc" };
 }
 
 push @tests,
-  {
-    'format' => 'asciidoc',
-    'todo'   => 'https://github.com/mquinson/po4a/issues/226',
-    'input'  => "fmt/asciidoc/TablesImageText.adoc",
-  },
   {
     'format'  => 'asciidoc',
     'options' => '-o tablecells=1',


### PR DESCRIPTION
Empty lines in tables managed as blocks must be passed "as is".

Fixes #226