### PR TITLE
asciidoc: tolerate underline length variations in two lines titles

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,8 @@ Tests:
  * Also ignore 'Project-Id-Version' when diffing PO files (GitHub's #224)
  * asciidoc: reactivate tablecells tests
  * asciidoc: fix management of images in tables (Github's #226)
+ * asciidoc: tolerate underline length variations in two lines titles
+   (Github's #212)
 
 Translations:
  * Updated: Dutch, thanks Frans Spiesschaert.

--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -394,14 +394,21 @@ sub parse {
             and
 
             # subtract one because chars includes the newline on the paragraph
-            ( ( chars( $paragraph, $self->{TT}{po_in}{encoder}, $ref ) - 1 ) == ( length($line) ) )
+            ( abs( ( chars( $paragraph, $self->{TT}{po_in}{encoder}, $ref ) - 1 ) - length($line) ) < 3 )
           )
         {
             # Found title
+
             $wrapped_mode = 0;
             my $level = $line;
             $level     =~ s/^(.).*$/$1/;
             $paragraph =~ s/\n$//s;
+
+            if (chars( $paragraph, $self->{TT}{po_in}{encoder}, $ref ) != length($line) )
+            {
+                print STDERR "$ref: Two line title type '$level' detected for '$paragraph' but the underlines is not within the tolerance +/- 2 chars of length of title\n"
+            }
+
             my $t = $self->translate(
                 $paragraph,
                 $self->{ref},

--- a/t/fmt/asciidoc/Titles.adoc
+++ b/t/fmt/asciidoc/Titles.adoc
@@ -22,3 +22,9 @@ Title level 4
 ==== Section title (level 3) ====
 
 ===== Section title (level 4) =====
+
+Title level 2 short
+~~~~~~~~~~~~~~~~~
+
+Title level 2 long
+~~~~~~~~~~~~~~~~~~~~

--- a/t/fmt/asciidoc/Titles.norm
+++ b/t/fmt/asciidoc/Titles.norm
@@ -22,3 +22,9 @@ Title level 4
 ==== Section title (level 3) ====
 
 ===== Section title (level 4) =====
+
+Title level 2 short
+~~~~~~~~~~~~~~~~~~~
+
+Title level 2 long
+~~~~~~~~~~~~~~~~~~

--- a/t/fmt/asciidoc/Titles.norm.stderr
+++ b/t/fmt/asciidoc/Titles.norm.stderr
@@ -1,0 +1,2 @@
+Titles.adoc:27: Two line title type '~' detected for 'Title level 2 short' but the underlines is not within the tolerance +/- 2 chars of length of title
+Titles.adoc:30: Two line title type '~' detected for 'Title level 2 long' but the underlines is not within the tolerance +/- 2 chars of length of title

--- a/t/fmt/asciidoc/Titles.po
+++ b/t/fmt/asciidoc/Titles.po
@@ -75,3 +75,15 @@ msgstr "SECTION TITLE (LEVEL 3)"
 #, no-wrap
 msgid "Section title (level 4)"
 msgstr "SECTION TITLE (LEVEL 4)"
+
+#. type: Title ~
+#: Titles.adoc:27
+#, no-wrap
+msgid "Title level 2 short"
+msgstr "TITLE LEVEL 2 SHORT"
+
+#. type: Title ~
+#: Titles.adoc:30
+#, no-wrap
+msgid "Title level 2 long"
+msgstr "TITLE LEVEL 2 LONG"

--- a/t/fmt/asciidoc/Titles.pot
+++ b/t/fmt/asciidoc/Titles.pot
@@ -75,3 +75,15 @@ msgstr ""
 #, no-wrap
 msgid "Section title (level 4)"
 msgstr ""
+
+#. type: Title ~
+#: Titles.adoc:27
+#, no-wrap
+msgid "Title level 2 short"
+msgstr ""
+
+#. type: Title ~
+#: Titles.adoc:30
+#, no-wrap
+msgid "Title level 2 long"
+msgstr ""

--- a/t/fmt/asciidoc/Titles.trans
+++ b/t/fmt/asciidoc/Titles.trans
@@ -22,3 +22,9 @@ TITLE LEVEL 4
 ==== SECTION TITLE (LEVEL 3) ====
 
 ===== SECTION TITLE (LEVEL 4) =====
+
+TITLE LEVEL 2 SHORT
+~~~~~~~~~~~~~~~~~~~
+
+TITLE LEVEL 2 LONG
+~~~~~~~~~~~~~~~~~~

--- a/t/fmt/asciidoc/Titles.trans.stderr
+++ b/t/fmt/asciidoc/Titles.trans.stderr
@@ -1,0 +1,2 @@
+Titles.adoc:27: Two line title type '~' detected for 'Title level 2 short' but the underlines is not within the tolerance +/- 2 chars of length of title
+Titles.adoc:30: Two line title type '~' detected for 'Title level 2 long' but the underlines is not within the tolerance +/- 2 chars of length of title


### PR DESCRIPTION
Two lines titles are tolerant wrt to underline length (±2 chars of
title length). The spec stipulates that the underline's length must be
even but this is not checked here.

Fixes #212