### PR TITLE
Fix --srcdir handling

### DIFF
--- a/po4a
+++ b/po4a
@@ -1513,6 +1513,10 @@ if ( not $po4a_opts{"no-update"} ) {
             my $updated_potfile = find_output_file($pot_filename);
 
             if ( -e $infile ) {
+                my $dir = dirname( $outfile );
+                if ( not -d $dir ) {
+                    mkdir $dir or die wrap_msg( gettext("Can't create directory '%s': %s"), $dir, $! );
+                }
 
                 my $msgmerge_opt = $po4a_opts{"msgmerge-opt"};
                 $msgmerge_opt =~ s/\$lang\b/$lang/g if scalar @langs;

--- a/po4a
+++ b/po4a
@@ -1054,7 +1054,7 @@ while (<CONFIG>) {
         opendir PO_DIR, find_input_file($po_directory)
           or die wrap_ref_mod( "$config_file:$nb", "", gettext("Cannot list the '%s' directory"), $po_directory );
 
-        foreach my $f ( readdir PO_DIR ) {
+        foreach my $f ( sort readdir PO_DIR ) {
             next unless -f find_input_file("$po_directory/$f");
             if ( $f =~ m/^(.*)\.po$/ ) {
                 push @langs, $1;

--- a/po4a
+++ b/po4a
@@ -223,8 +223,8 @@ Set the base directory for all input documents specified in the B<po4a>
 configuration file. 
 
 If both I<destdir> and I<srcdir> are specified, input files are
-searched in the following directories, in order: I<destdir>,
-I<srcdir> and the current directory. Output files are written to I<destdir> if
+searched in the following directories, in order: I<destdir>, the current
+directory and I<srcdir>. Output files are written to I<destdir> if
 specified, or to the current directory.
 
 =item B<--destdir> I<DESTDIR>
@@ -876,7 +876,7 @@ sub find_input_file {
     my $debug    = $_[1];
     print STDERR "Search for input file $filename\n" if $debug;
     return $filename                                 if ( File::Spec->file_name_is_absolute($filename) );
-    foreach ( ( $destdir, $srcdir, $calldir ) ) {
+    foreach ( ( $destdir, $calldir, $srcdir ) ) {
         next unless defined $_;
         my $p = File::Spec->catfile( $_, $filename );
         print STDERR "Test $p: " . ( -e $p ? "OK" : "nope" ) . "\n"

--- a/po4a
+++ b/po4a
@@ -1510,7 +1510,7 @@ if ( not $po4a_opts{"no-update"} ) {
         foreach $lang ( sort keys %po_filename ) {
             my ( $infile, $outfile ) =
               ( find_input_file( $po_filename{$lang} ), find_output_file( $po_filename{$lang} ) );
-            my $updated_potfile = find_output_file($pot_filename);
+            my $updated_potfile = find_input_file($pot_filename);
 
             if ( -e $infile ) {
                 my $dir = dirname( $outfile );


### PR DESCRIPTION
This fixes several issues with the --srcdir handling so that it does the right thing. These were causing build failures in at least dpkg and aptitude. I've also checked all other instances of find_output_file and they look ok, but a second look would make sense anyway. :)

Fixes Debian bug #960892.