### PR TITLE
asciidoc: strict option to match strictly equal block fences

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,9 @@ __   __/ _ \ / /_  / _ \
  \ V /| |_| | (_) | |_| |
   \_/  \___(_)___/ \___/          (not released yet)
 
+Asciidoc:
+ * Introduce "compat" option to parse like asciidoc or asciidoctor.
+
 Text (and Markdown):
  * Fix the support of nested lists (GitHub's #131).
 

--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -73,6 +73,12 @@ this option.
 This option is a flag that enables sub-table segmentation into cell content.
 The segmentation is limited to cell content, without any parsing inside of it.
 
+=item B<compat>
+
+Switch parsing rules to compatibility with different tools. Available options are
+"asciidoc" or "asciidoctor". Asciidoctor has stricter parsing rules, such as
+equality of length of opening and closing block fences.
+
 =back
 
 =head1 INLINE CUSTOMIZATION
@@ -144,6 +150,7 @@ sub initialize {
     $self->{options}{'definitions'}    = '';
     $self->{options}{'noimagetargets'} = 0;
     $self->{options}{'tablecells'}     = 0;
+    $self->{options}{'compat'}         = 'asciidoc';
 
     foreach my $opt ( keys %options ) {
         die wrap_mod( "po4a::asciidoc", dgettext( "po4a", "Unknown option: %s" ), $opt )
@@ -456,7 +463,9 @@ sub parse {
             # Found one delimited block
             my $t = $line;
             $t =~ s/^(.).*$/$1/;
+            my $l = length $line;
             my $type = "delimited block $t";
+            $type = "$type $l"  if ( $self->{options}{'compat'} eq 'asciidoctor' );
             if ( defined $self->{verbatim} and ( $self->{type} ne $type ) ) {
                 $paragraph .= "$line\n";
             } else {

--- a/t/fmt-asciidoc.t
+++ b/t/fmt-asciidoc.t
@@ -21,6 +21,12 @@ foreach my $t (
 push @tests,
   {
     'format'  => 'asciidoc',
+    'options' => '-o compat=asciidoctor',
+    'input'   => 'fmt/asciidoc/StrictDelimitedBlocks.adoc',
+    'doc'     => 'asciidoctor block fence parsing',
+  },
+  {
+    'format'  => 'asciidoc',
     'options' => '-o tablecells=1',
     'input'   => 'fmt/asciidoc/TablesCells.adoc',
     'doc'     => 'test table cells segmentation',

--- a/t/fmt/asciidoc/StrictDelimitedBlocks.adoc
+++ b/t/fmt/asciidoc/StrictDelimitedBlocks.adoc
@@ -1,0 +1,194 @@
+//po4a: style[,caption]
+Test Delimited Blocks
+=====================
+
+Predefined Delimited Blocks
+---------------------------
+
+CommentBlock
+
+//////////////////////////
+This is a Comment block.
+This is a Comment block.
+
+  This is a Comment block.
+  This is a Comment block.
+
+  - This is a Comment block.
+    This is a Comment block.
+//////////////////////////
+
+PassthroughBlock
+
+++++++++++++++++++++++++++
+This is a Passthrough block.
+This is a Passthrough block.
+
+  This is a Passthrough block.
+  This is a Passthrough block.
+
+  - This is a Passthrough block.
+    This is a Passthrough block.
+++++++++++++++++++++++++++
+
+ListingBlock
+
+--------------------------
+This is a Listing block.
+This is a Listing block.
+
+  This is a Listing block.
+  This is a Listing block.
+
+  - This is a Listing block.
+    This is a Listing block.
+--------------------------
+
+LiteralBlock
+
+..........................
+This is a Literal block.
+This is a Literal block.
+
+  This is a Literal block.
+  This is a Literal block.
+
+  - This is a Literal block.
+    This is a Literal block.
+..........................
+
+SidebarBlock
+
+**************************
+This is a Sidebar block.
+This is a Sidebar block.
+
+  This is a Sidebar block.
+  This is a Sidebar block.
+
+  - This is a Sidebar block.
+    This is a Sidebar block.
+**************************
+
+QuoteBlock
+
+__________________________
+This is a Quote block.
+This is a Quote block.
+
+  This is a Quote block.
+  This is a Quote block.
+
+  - This is a Quote block.
+    This is a Quote block.
+__________________________
+
+
+[quote, Bertrand Russell, The World of Mathematics (1956)]
+____________________________________________________________________
+A good notation has subtlety and suggestiveness which at times makes
+it almost seem like a live teacher.
+____________________________________________________________________
+
+[verse, William Blake, from Auguries of Innocence]
+__________________________________________________
+To see a world in a grain of sand,
+And a heaven in a wild flower,
+Hold infinity in the palm of your hand,
+And eternity in an hour.
+__________________________________________________
+
+ExampleBlock
+
+==========================
+This is a Example block.
+This is a Example block.
+
+  This is a Example block.
+  This is a Example block.
+
+  - This is a Example block.
+    This is a Example block.
+==========================
+
+.An example
+=====================================================================
+Qui in magna commodo, est labitur dolorum an. Est ne magna primis
+adolescens.
+=====================================================================
+
+[caption="Example 1: "]
+.An example with a custom caption
+=====================================================================
+Qui in magna commodo, est labitur dolorum an. Est ne magna primis
+adolescens.
+=====================================================================
+
+[NOTE]
+.A NOTE block
+=====================================================================
+Qui in magna commodo, est labitur dolorum an. Est ne magna primis
+adolescens.
+
+. Fusce euismod commodo velit.
+. Vivamus fringilla mi eu lacus.
+  .. Fusce euismod commodo velit.
+  .. Vivamus fringilla mi eu lacus.
+. Donec eget arcu bibendum
+  nunc consequat lobortis.
+=====================================================================
+
+Filter blocks
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+This is a Filter block.
+This is a Filter block.
+
+  This is a Filter block.
+  This is a Filter block.
+
+  - This is a Filter block.
+    This is a Filter block.
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+
+//////////////////////////
+test
+
+--------------------------
+Listing inside Comment
+--------------------------
+
+end of test
+//////////////////////////
+
+++++++++++++++++++++++++++
+test
+
+--------------------------
+Listing inside Passthrough
+--------------------------
+
+end of test
+++++++++++++++++++++++++++
+
+--------------------------
+test
+
+__________________________
+QuoteBlock inside Listing
+__________________________
+
+end of test
+--------------------------
+
+----
+test
+
+-------------------------------
+Listing inside a Listing
+-------------------------------
+
+end of test
+----

--- a/t/fmt/asciidoc/StrictDelimitedBlocks.norm
+++ b/t/fmt/asciidoc/StrictDelimitedBlocks.norm
@@ -1,0 +1,167 @@
+Test Delimited Blocks
+=====================
+
+Predefined Delimited Blocks
+---------------------------
+
+CommentBlock
+
+
+PassthroughBlock
+
+++++++++++++++++++++++++++
+This is a Passthrough block.
+This is a Passthrough block.
+
+  This is a Passthrough block.
+  This is a Passthrough block.
+
+  - This is a Passthrough block.
+    This is a Passthrough block.
+++++++++++++++++++++++++++
+
+ListingBlock
+
+--------------------------
+This is a Listing block.
+This is a Listing block.
+
+  This is a Listing block.
+  This is a Listing block.
+
+  - This is a Listing block.
+    This is a Listing block.
+--------------------------
+
+LiteralBlock
+
+..........................
+This is a Literal block.
+This is a Literal block.
+
+  This is a Literal block.
+  This is a Literal block.
+
+  - This is a Literal block.
+    This is a Literal block.
+..........................
+
+SidebarBlock
+
+**************************
+This is a Sidebar block.  This is a Sidebar block.
+
+  This is a Sidebar block.
+  This is a Sidebar block.
+
+  - This is a Sidebar block.  This is a Sidebar block.
+**************************
+
+QuoteBlock
+
+__________________________
+This is a Quote block.  This is a Quote block.
+
+  This is a Quote block.
+  This is a Quote block.
+
+  - This is a Quote block.  This is a Quote block.
+__________________________
+
+
+[quote, "Bertrand Russell", "The World of Mathematics (1956)"]
+____________________________________________________________________
+A good notation has subtlety and suggestiveness which at times makes it
+almost seem like a live teacher.
+____________________________________________________________________
+
+[verse, "William Blake", "from Auguries of Innocence"]
+__________________________________________________
+To see a world in a grain of sand,
+And a heaven in a wild flower,
+Hold infinity in the palm of your hand,
+And eternity in an hour.
+__________________________________________________
+
+ExampleBlock
+
+==========================
+This is a Example block.  This is a Example block.
+
+  This is a Example block.
+  This is a Example block.
+
+  - This is a Example block.  This is a Example block.
+==========================
+
+.An example
+=====================================================================
+Qui in magna commodo, est labitur dolorum an. Est ne magna primis
+adolescens.
+=====================================================================
+
+[caption="Example 1: "]
+.An example with a custom caption
+=====================================================================
+Qui in magna commodo, est labitur dolorum an. Est ne magna primis
+adolescens.
+=====================================================================
+
+[NOTE]
+.A NOTE block
+=====================================================================
+Qui in magna commodo, est labitur dolorum an. Est ne magna primis
+adolescens.
+
+. Fusce euismod commodo velit.
+. Vivamus fringilla mi eu lacus.
+  .. Fusce euismod commodo velit.
+  .. Vivamus fringilla mi eu lacus.
+. Donec eget arcu bibendum nunc consequat lobortis.
+=====================================================================
+
+Filter blocks
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+This is a Filter block.
+This is a Filter block.
+
+  This is a Filter block.
+  This is a Filter block.
+
+  - This is a Filter block.
+    This is a Filter block.
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+
+
+++++++++++++++++++++++++++
+test
+
+--------------------------
+Listing inside Passthrough
+--------------------------
+
+end of test
+++++++++++++++++++++++++++
+
+--------------------------
+test
+
+__________________________
+QuoteBlock inside Listing
+__________________________
+
+end of test
+--------------------------
+
+----
+test
+
+-------------------------------
+Listing inside a Listing
+-------------------------------
+
+end of test
+----

--- a/t/fmt/asciidoc/StrictDelimitedBlocks.po
+++ b/t/fmt/asciidoc/StrictDelimitedBlocks.po
@@ -1,0 +1,352 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2012-10-09 09:04+0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@LI.ORG>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: TEXT/PLAIN; CHARSET=UTF-8\n"
+"Content-Transfer-Encoding: 8BIT\n"
+
+#. type: Title =
+#: StrictDelimitedBlocks.adoc:3
+#, no-wrap
+msgid "Test Delimited Blocks"
+msgstr "TEST DELIMITED BLOCKS"
+
+#. type: Title -
+#: StrictDelimitedBlocks.adoc:6
+#, no-wrap
+msgid "Predefined Delimited Blocks"
+msgstr "PREDEFINED DELIMITED BLOCKS"
+
+#. type: Plain text
+#: StrictDelimitedBlocks.adoc:9
+msgid "CommentBlock"
+msgstr "COMMENTBLOCK"
+
+#
+#
+#. This is a Comment block.
+#. This is a Comment block.
+#.   This is a Comment block.
+#.   This is a Comment block.
+#.   - This is a Comment block.
+#.     This is a Comment block.
+#. type: Plain text
+#: StrictDelimitedBlocks.adoc:22
+msgid "PassthroughBlock"
+msgstr "PASSTHROUGHBLOCK"
+
+#. type: delimited block + 26
+#: StrictDelimitedBlocks.adoc:26
+#, no-wrap
+msgid ""
+"This is a Passthrough block.\n"
+"This is a Passthrough block.\n"
+msgstr ""
+"THIS IS A PASSTHROUGH BLOCK.\n"
+"THIS IS A PASSTHROUGH BLOCK.\n"
+
+#. type: delimited block + 26
+#: StrictDelimitedBlocks.adoc:29
+#, no-wrap
+msgid ""
+"  This is a Passthrough block.\n"
+"  This is a Passthrough block.\n"
+msgstr ""
+"  THIS IS A PASSTHROUGH BLOCK.\n"
+"  THIS IS A PASSTHROUGH BLOCK.\n"
+
+#. type: delimited block + 26
+#: StrictDelimitedBlocks.adoc:32
+#, no-wrap
+msgid ""
+"  - This is a Passthrough block.\n"
+"    This is a Passthrough block.\n"
+msgstr ""
+"  - THIS IS A PASSTHROUGH BLOCK.\n"
+"    THIS IS A PASSTHROUGH BLOCK.\n"
+
+#. type: Plain text
+#: StrictDelimitedBlocks.adoc:35
+msgid "ListingBlock"
+msgstr "LISTINGBLOCK"
+
+#. type: delimited block - 26
+#: StrictDelimitedBlocks.adoc:39
+#, no-wrap
+msgid ""
+"This is a Listing block.\n"
+"This is a Listing block.\n"
+msgstr ""
+"THIS IS A LISTING BLOCK.\n"
+"THIS IS A LISTING BLOCK.\n"
+
+#. type: delimited block - 26
+#: StrictDelimitedBlocks.adoc:42
+#, no-wrap
+msgid ""
+"  This is a Listing block.\n"
+"  This is a Listing block.\n"
+msgstr ""
+"  THIS IS A LISTING BLOCK.\n"
+"  THIS IS A LISTING BLOCK.\n"
+
+#. type: delimited block - 26
+#: StrictDelimitedBlocks.adoc:45
+#, no-wrap
+msgid ""
+"  - This is a Listing block.\n"
+"    This is a Listing block.\n"
+msgstr ""
+"  - THIS IS A LISTING BLOCK.\n"
+"    THIS IS A LISTING BLOCK.\n"
+
+#. type: Plain text
+#: StrictDelimitedBlocks.adoc:48
+msgid "LiteralBlock"
+msgstr "LITERALBLOCK"
+
+#. type: delimited block . 26
+#: StrictDelimitedBlocks.adoc:52
+#, no-wrap
+msgid ""
+"This is a Literal block.\n"
+"This is a Literal block.\n"
+msgstr ""
+"THIS IS A LITERAL BLOCK.\n"
+"THIS IS A LITERAL BLOCK.\n"
+
+#. type: delimited block . 26
+#: StrictDelimitedBlocks.adoc:55
+#, no-wrap
+msgid ""
+"  This is a Literal block.\n"
+"  This is a Literal block.\n"
+msgstr ""
+"  THIS IS A LITERAL BLOCK.\n"
+"  THIS IS A LITERAL BLOCK.\n"
+
+#. type: delimited block . 26
+#: StrictDelimitedBlocks.adoc:58
+#, no-wrap
+msgid ""
+"  - This is a Literal block.\n"
+"    This is a Literal block.\n"
+msgstr ""
+"  - THIS IS A LITERAL BLOCK.\n"
+"    THIS IS A LITERAL BLOCK.\n"
+
+#. type: Plain text
+#: StrictDelimitedBlocks.adoc:61
+msgid "SidebarBlock"
+msgstr "SIDEBARBLOCK"
+
+#. type: delimited block * 26
+#: StrictDelimitedBlocks.adoc:65 StrictDelimitedBlocks.adoc:71
+msgid "This is a Sidebar block.  This is a Sidebar block."
+msgstr "THIS IS A SIDEBAR BLOCK.  THIS IS A SIDEBAR BLOCK."
+
+#. type: delimited block * 26
+#: StrictDelimitedBlocks.adoc:68
+#, no-wrap
+msgid ""
+"  This is a Sidebar block.\n"
+"  This is a Sidebar block.\n"
+msgstr ""
+"  THIS IS A SIDEBAR BLOCK.\n"
+"  THIS IS A SIDEBAR BLOCK.\n"
+
+#. type: Plain text
+#: StrictDelimitedBlocks.adoc:74
+msgid "QuoteBlock"
+msgstr "QUOTEBLOCK"
+
+#. type: delimited block _ 26
+#: StrictDelimitedBlocks.adoc:78 StrictDelimitedBlocks.adoc:84
+msgid "This is a Quote block.  This is a Quote block."
+msgstr "THIS IS A QUOTE BLOCK.  THIS IS A QUOTE BLOCK."
+
+#. type: delimited block _ 26
+#: StrictDelimitedBlocks.adoc:81
+#, no-wrap
+msgid ""
+"  This is a Quote block.\n"
+"  This is a Quote block.\n"
+msgstr ""
+"  THIS IS A QUOTE BLOCK.\n"
+"  THIS IS A QUOTE BLOCK.\n"
+
+#. type: Positional ($2) AttributeList argument for style 'quote'
+#: StrictDelimitedBlocks.adoc:87
+#, no-wrap
+msgid "Bertrand Russell"
+msgstr "BERTRAND RUSSELL"
+
+#. type: Positional ($3) AttributeList argument for style 'quote'
+#: StrictDelimitedBlocks.adoc:87
+#, no-wrap
+msgid "The World of Mathematics (1956)"
+msgstr "THE WORLD OF MATHEMATICS (1956)"
+
+#. type: delimited block _ 68
+#: StrictDelimitedBlocks.adoc:91
+msgid ""
+"A good notation has subtlety and suggestiveness which at times makes it "
+"almost seem like a live teacher."
+msgstr ""
+"A GOOD NOTATION HAS SUBTLETY AND SUGGESTIVENESS WHICH AT TIMES MAKES IT "
+"ALMOST SEEM LIKE A LIVE TEACHER."
+
+#. type: Positional ($2) AttributeList argument for style 'verse'
+#: StrictDelimitedBlocks.adoc:93
+#, no-wrap
+msgid "William Blake"
+msgstr "WILLIAM BLAKE"
+
+#. type: Positional ($3) AttributeList argument for style 'verse'
+#: StrictDelimitedBlocks.adoc:93
+#, no-wrap
+msgid "from Auguries of Innocence"
+msgstr "FROM AUGURIES OF INNOCENCE"
+
+#. type: delimited block _ 50
+#: StrictDelimitedBlocks.adoc:99
+#, no-wrap
+msgid ""
+"To see a world in a grain of sand,\n"
+"And a heaven in a wild flower,\n"
+"Hold infinity in the palm of your hand,\n"
+"And eternity in an hour.\n"
+msgstr ""
+"TO SEE A WORLD IN A GRAIN OF SAND,\n"
+"AND A HEAVEN IN A WILD FLOWER,\n"
+"HOLD INFINITY IN THE PALM OF YOUR HAND,\n"
+"AND ETERNITY IN AN HOUR.\n"
+
+#. type: Plain text
+#: StrictDelimitedBlocks.adoc:102
+msgid "ExampleBlock"
+msgstr "EXAMPLEBLOCK"
+
+#. type: delimited block = 26
+#: StrictDelimitedBlocks.adoc:106 StrictDelimitedBlocks.adoc:112
+msgid "This is a Example block.  This is a Example block."
+msgstr "THIS IS A EXAMPLE BLOCK.  THIS IS A EXAMPLE BLOCK."
+
+#. type: delimited block = 26
+#: StrictDelimitedBlocks.adoc:109
+#, no-wrap
+msgid ""
+"  This is a Example block.\n"
+"  This is a Example block.\n"
+msgstr ""
+"  THIS IS A EXAMPLE BLOCK.\n"
+"  THIS IS A EXAMPLE BLOCK.\n"
+
+#. type: Block title
+#: StrictDelimitedBlocks.adoc:114
+#, no-wrap
+msgid "An example"
+msgstr "AN EXAMPLE"
+
+#. type: delimited block = 69
+#: StrictDelimitedBlocks.adoc:118 StrictDelimitedBlocks.adoc:125 StrictDelimitedBlocks.adoc:132
+msgid ""
+"Qui in magna commodo, est labitur dolorum an. Est ne magna primis adolescens."
+msgstr ""
+"QUI IN MAGNA COMMODO, EST LABITUR DOLORUM AN. EST NE MAGNA PRIMIS ADOLESCENS."
+
+#. type: Named 'caption' AttributeList argument for style 'caption'
+#: StrictDelimitedBlocks.adoc:120
+#, no-wrap
+msgid "Example 1: "
+msgstr "EXAMPLE 1: "
+
+#. type: Block title
+#: StrictDelimitedBlocks.adoc:121
+#, no-wrap
+msgid "An example with a custom caption"
+msgstr "AN EXAMPLE WITH A CUSTOM CAPTION"
+
+#. type: Block title
+#: StrictDelimitedBlocks.adoc:128
+#, no-wrap
+msgid "A NOTE block"
+msgstr "A NOTE BLOCK"
+
+#. type: delimited block = 69
+#: StrictDelimitedBlocks.adoc:134 StrictDelimitedBlocks.adoc:136
+msgid "Fusce euismod commodo velit."
+msgstr "FUSCE EUISMOD COMMODO VELIT."
+
+#. type: delimited block = 69
+#: StrictDelimitedBlocks.adoc:135 StrictDelimitedBlocks.adoc:137
+msgid "Vivamus fringilla mi eu lacus."
+msgstr "VIVAMUS FRINGILLA MI EU LACUS."
+
+#. type: delimited block = 69
+#: StrictDelimitedBlocks.adoc:139
+msgid "Donec eget arcu bibendum nunc consequat lobortis."
+msgstr "DONEC EGET ARCU BIBENDUM NUNC CONSEQUAT LOBORTIS."
+
+#. type: Plain text
+#: StrictDelimitedBlocks.adoc:142
+msgid "Filter blocks"
+msgstr "FILTER BLOCKS"
+
+#. type: delimited block - 4
+#: StrictDelimitedBlocks.adoc:168 StrictDelimitedBlocks.adoc:178 StrictDelimitedBlocks.adoc:188
+#, no-wrap
+msgid "test\n"
+msgstr "TEST\n"
+
+#. type: delimited block + 26
+#: StrictDelimitedBlocks.adoc:172
+#, no-wrap
+msgid ""
+"--------------------------\n"
+"Listing inside Passthrough\n"
+"--------------------------\n"
+msgstr ""
+"--------------------------\n"
+"LISTING INSIDE PASSTHROUGH\n"
+"--------------------------\n"
+
+#. type: delimited block - 4
+#: StrictDelimitedBlocks.adoc:174 StrictDelimitedBlocks.adoc:184 StrictDelimitedBlocks.adoc:194
+#, no-wrap
+msgid "end of test\n"
+msgstr "END OF TEST\n"
+
+#. type: delimited block - 26
+#: StrictDelimitedBlocks.adoc:182
+#, no-wrap
+msgid ""
+"__________________________\n"
+"QuoteBlock inside Listing\n"
+"__________________________\n"
+msgstr ""
+"__________________________\n"
+"QUOTEBLOCK INSIDE LISTING\n"
+"__________________________\n"
+
+#. type: delimited block - 4
+#: StrictDelimitedBlocks.adoc:192
+#, no-wrap
+msgid ""
+"-------------------------------\n"
+"Listing inside a Listing\n"
+"-------------------------------\n"
+msgstr ""
+"-------------------------------\n"
+"LISTING INSIDE A LISTING\n"
+"-------------------------------\n"

--- a/t/fmt/asciidoc/StrictDelimitedBlocks.pot
+++ b/t/fmt/asciidoc/StrictDelimitedBlocks.pot
@@ -1,0 +1,317 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2012-10-09 09:04+0300\n"
+"PO-Revision-Date: 2020-05-30 18:26+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Title =
+#: StrictDelimitedBlocks.adoc:3
+#, no-wrap
+msgid "Test Delimited Blocks"
+msgstr ""
+
+#. type: Title -
+#: StrictDelimitedBlocks.adoc:6
+#, no-wrap
+msgid "Predefined Delimited Blocks"
+msgstr ""
+
+#. type: Plain text
+#: StrictDelimitedBlocks.adoc:9
+msgid "CommentBlock"
+msgstr ""
+
+#. This is a Comment block.
+#. This is a Comment block.
+#
+#.   This is a Comment block.
+#.   This is a Comment block.
+#
+#.   - This is a Comment block.
+#.     This is a Comment block.
+#. type: Plain text
+#: StrictDelimitedBlocks.adoc:22
+msgid "PassthroughBlock"
+msgstr ""
+
+#. type: delimited block + 26
+#: StrictDelimitedBlocks.adoc:26
+#, no-wrap
+msgid ""
+"This is a Passthrough block.\n"
+"This is a Passthrough block.\n"
+msgstr ""
+
+#. type: delimited block + 26
+#: StrictDelimitedBlocks.adoc:29
+#, no-wrap
+msgid ""
+"  This is a Passthrough block.\n"
+"  This is a Passthrough block.\n"
+msgstr ""
+
+#. type: delimited block + 26
+#: StrictDelimitedBlocks.adoc:32
+#, no-wrap
+msgid ""
+"  - This is a Passthrough block.\n"
+"    This is a Passthrough block.\n"
+msgstr ""
+
+#. type: Plain text
+#: StrictDelimitedBlocks.adoc:35
+msgid "ListingBlock"
+msgstr ""
+
+#. type: delimited block - 26
+#: StrictDelimitedBlocks.adoc:39
+#, no-wrap
+msgid ""
+"This is a Listing block.\n"
+"This is a Listing block.\n"
+msgstr ""
+
+#. type: delimited block - 26
+#: StrictDelimitedBlocks.adoc:42
+#, no-wrap
+msgid ""
+"  This is a Listing block.\n"
+"  This is a Listing block.\n"
+msgstr ""
+
+#. type: delimited block - 26
+#: StrictDelimitedBlocks.adoc:45
+#, no-wrap
+msgid ""
+"  - This is a Listing block.\n"
+"    This is a Listing block.\n"
+msgstr ""
+
+#. type: Plain text
+#: StrictDelimitedBlocks.adoc:48
+msgid "LiteralBlock"
+msgstr ""
+
+#. type: delimited block . 26
+#: StrictDelimitedBlocks.adoc:52
+#, no-wrap
+msgid ""
+"This is a Literal block.\n"
+"This is a Literal block.\n"
+msgstr ""
+
+#. type: delimited block . 26
+#: StrictDelimitedBlocks.adoc:55
+#, no-wrap
+msgid ""
+"  This is a Literal block.\n"
+"  This is a Literal block.\n"
+msgstr ""
+
+#. type: delimited block . 26
+#: StrictDelimitedBlocks.adoc:58
+#, no-wrap
+msgid ""
+"  - This is a Literal block.\n"
+"    This is a Literal block.\n"
+msgstr ""
+
+#. type: Plain text
+#: StrictDelimitedBlocks.adoc:61
+msgid "SidebarBlock"
+msgstr ""
+
+#. type: delimited block * 26
+#: StrictDelimitedBlocks.adoc:65 StrictDelimitedBlocks.adoc:71
+msgid "This is a Sidebar block.  This is a Sidebar block."
+msgstr ""
+
+#. type: delimited block * 26
+#: StrictDelimitedBlocks.adoc:68
+#, no-wrap
+msgid ""
+"  This is a Sidebar block.\n"
+"  This is a Sidebar block.\n"
+msgstr ""
+
+#. type: Plain text
+#: StrictDelimitedBlocks.adoc:74
+msgid "QuoteBlock"
+msgstr ""
+
+#. type: delimited block _ 26
+#: StrictDelimitedBlocks.adoc:78 StrictDelimitedBlocks.adoc:84
+msgid "This is a Quote block.  This is a Quote block."
+msgstr ""
+
+#. type: delimited block _ 26
+#: StrictDelimitedBlocks.adoc:81
+#, no-wrap
+msgid ""
+"  This is a Quote block.\n"
+"  This is a Quote block.\n"
+msgstr ""
+
+#. type: Positional ($2) AttributeList argument for style 'quote'
+#: StrictDelimitedBlocks.adoc:87
+#, no-wrap
+msgid "Bertrand Russell"
+msgstr ""
+
+#. type: Positional ($3) AttributeList argument for style 'quote'
+#: StrictDelimitedBlocks.adoc:87
+#, no-wrap
+msgid "The World of Mathematics (1956)"
+msgstr ""
+
+#. type: delimited block _ 68
+#: StrictDelimitedBlocks.adoc:91
+msgid ""
+"A good notation has subtlety and suggestiveness which at times makes it "
+"almost seem like a live teacher."
+msgstr ""
+
+#. type: Positional ($2) AttributeList argument for style 'verse'
+#: StrictDelimitedBlocks.adoc:93
+#, no-wrap
+msgid "William Blake"
+msgstr ""
+
+#. type: Positional ($3) AttributeList argument for style 'verse'
+#: StrictDelimitedBlocks.adoc:93
+#, no-wrap
+msgid "from Auguries of Innocence"
+msgstr ""
+
+#. type: delimited block _ 50
+#: StrictDelimitedBlocks.adoc:99
+#, no-wrap
+msgid ""
+"To see a world in a grain of sand,\n"
+"And a heaven in a wild flower,\n"
+"Hold infinity in the palm of your hand,\n"
+"And eternity in an hour.\n"
+msgstr ""
+
+#. type: Plain text
+#: StrictDelimitedBlocks.adoc:102
+msgid "ExampleBlock"
+msgstr ""
+
+#. type: delimited block = 26
+#: StrictDelimitedBlocks.adoc:106 StrictDelimitedBlocks.adoc:112
+msgid "This is a Example block.  This is a Example block."
+msgstr ""
+
+#. type: delimited block = 26
+#: StrictDelimitedBlocks.adoc:109
+#, no-wrap
+msgid ""
+"  This is a Example block.\n"
+"  This is a Example block.\n"
+msgstr ""
+
+#. type: Block title
+#: StrictDelimitedBlocks.adoc:114
+#, no-wrap
+msgid "An example"
+msgstr ""
+
+#. type: delimited block = 69
+#: StrictDelimitedBlocks.adoc:118 StrictDelimitedBlocks.adoc:125
+#: StrictDelimitedBlocks.adoc:132
+msgid ""
+"Qui in magna commodo, est labitur dolorum an. Est ne magna primis "
+"adolescens."
+msgstr ""
+
+#. type: Named 'caption' AttributeList argument for style 'caption'
+#: StrictDelimitedBlocks.adoc:120
+#, no-wrap
+msgid "Example 1: "
+msgstr ""
+
+#. type: Block title
+#: StrictDelimitedBlocks.adoc:121
+#, no-wrap
+msgid "An example with a custom caption"
+msgstr ""
+
+#. type: Block title
+#: StrictDelimitedBlocks.adoc:128
+#, no-wrap
+msgid "A NOTE block"
+msgstr ""
+
+#. type: delimited block = 69
+#: StrictDelimitedBlocks.adoc:134 StrictDelimitedBlocks.adoc:136
+msgid "Fusce euismod commodo velit."
+msgstr ""
+
+#. type: delimited block = 69
+#: StrictDelimitedBlocks.adoc:135 StrictDelimitedBlocks.adoc:137
+msgid "Vivamus fringilla mi eu lacus."
+msgstr ""
+
+#. type: delimited block = 69
+#: StrictDelimitedBlocks.adoc:139
+msgid "Donec eget arcu bibendum nunc consequat lobortis."
+msgstr ""
+
+#. type: Plain text
+#: StrictDelimitedBlocks.adoc:142
+msgid "Filter blocks"
+msgstr ""
+
+#. type: delimited block - 4
+#: StrictDelimitedBlocks.adoc:168 StrictDelimitedBlocks.adoc:178
+#: StrictDelimitedBlocks.adoc:188
+#, no-wrap
+msgid "test\n"
+msgstr ""
+
+#. type: delimited block + 26
+#: StrictDelimitedBlocks.adoc:172
+#, no-wrap
+msgid ""
+"--------------------------\n"
+"Listing inside Passthrough\n"
+"--------------------------\n"
+msgstr ""
+
+#. type: delimited block - 4
+#: StrictDelimitedBlocks.adoc:174 StrictDelimitedBlocks.adoc:184
+#: StrictDelimitedBlocks.adoc:194
+#, no-wrap
+msgid "end of test\n"
+msgstr ""
+
+#. type: delimited block - 26
+#: StrictDelimitedBlocks.adoc:182
+#, no-wrap
+msgid ""
+"__________________________\n"
+"QuoteBlock inside Listing\n"
+"__________________________\n"
+msgstr ""
+
+#. type: delimited block - 4
+#: StrictDelimitedBlocks.adoc:192
+#, no-wrap
+msgid ""
+"-------------------------------\n"
+"Listing inside a Listing\n"
+"-------------------------------\n"
+msgstr ""

--- a/t/fmt/asciidoc/StrictDelimitedBlocks.trans
+++ b/t/fmt/asciidoc/StrictDelimitedBlocks.trans
@@ -1,0 +1,167 @@
+TEST DELIMITED BLOCKS
+=====================
+
+PREDEFINED DELIMITED BLOCKS
+---------------------------
+
+COMMENTBLOCK
+
+
+PASSTHROUGHBLOCK
+
+++++++++++++++++++++++++++
+THIS IS A PASSTHROUGH BLOCK.
+THIS IS A PASSTHROUGH BLOCK.
+
+  THIS IS A PASSTHROUGH BLOCK.
+  THIS IS A PASSTHROUGH BLOCK.
+
+  - THIS IS A PASSTHROUGH BLOCK.
+    THIS IS A PASSTHROUGH BLOCK.
+++++++++++++++++++++++++++
+
+LISTINGBLOCK
+
+--------------------------
+THIS IS A LISTING BLOCK.
+THIS IS A LISTING BLOCK.
+
+  THIS IS A LISTING BLOCK.
+  THIS IS A LISTING BLOCK.
+
+  - THIS IS A LISTING BLOCK.
+    THIS IS A LISTING BLOCK.
+--------------------------
+
+LITERALBLOCK
+
+..........................
+THIS IS A LITERAL BLOCK.
+THIS IS A LITERAL BLOCK.
+
+  THIS IS A LITERAL BLOCK.
+  THIS IS A LITERAL BLOCK.
+
+  - THIS IS A LITERAL BLOCK.
+    THIS IS A LITERAL BLOCK.
+..........................
+
+SIDEBARBLOCK
+
+**************************
+THIS IS A SIDEBAR BLOCK.  THIS IS A SIDEBAR BLOCK.
+
+  THIS IS A SIDEBAR BLOCK.
+  THIS IS A SIDEBAR BLOCK.
+
+  - THIS IS A SIDEBAR BLOCK.  THIS IS A SIDEBAR BLOCK.
+**************************
+
+QUOTEBLOCK
+
+__________________________
+THIS IS A QUOTE BLOCK.  THIS IS A QUOTE BLOCK.
+
+  THIS IS A QUOTE BLOCK.
+  THIS IS A QUOTE BLOCK.
+
+  - THIS IS A QUOTE BLOCK.  THIS IS A QUOTE BLOCK.
+__________________________
+
+
+[quote, "BERTRAND RUSSELL", "THE WORLD OF MATHEMATICS (1956)"]
+____________________________________________________________________
+A GOOD NOTATION HAS SUBTLETY AND SUGGESTIVENESS WHICH AT TIMES MAKES IT
+ALMOST SEEM LIKE A LIVE TEACHER.
+____________________________________________________________________
+
+[verse, "WILLIAM BLAKE", "FROM AUGURIES OF INNOCENCE"]
+__________________________________________________
+TO SEE A WORLD IN A GRAIN OF SAND,
+AND A HEAVEN IN A WILD FLOWER,
+HOLD INFINITY IN THE PALM OF YOUR HAND,
+AND ETERNITY IN AN HOUR.
+__________________________________________________
+
+EXAMPLEBLOCK
+
+==========================
+THIS IS A EXAMPLE BLOCK.  THIS IS A EXAMPLE BLOCK.
+
+  THIS IS A EXAMPLE BLOCK.
+  THIS IS A EXAMPLE BLOCK.
+
+  - THIS IS A EXAMPLE BLOCK.  THIS IS A EXAMPLE BLOCK.
+==========================
+
+.AN EXAMPLE
+=====================================================================
+QUI IN MAGNA COMMODO, EST LABITUR DOLORUM AN. EST NE MAGNA PRIMIS
+ADOLESCENS.
+=====================================================================
+
+[caption="EXAMPLE 1: "]
+.AN EXAMPLE WITH A CUSTOM CAPTION
+=====================================================================
+QUI IN MAGNA COMMODO, EST LABITUR DOLORUM AN. EST NE MAGNA PRIMIS
+ADOLESCENS.
+=====================================================================
+
+[NOTE]
+.A NOTE BLOCK
+=====================================================================
+QUI IN MAGNA COMMODO, EST LABITUR DOLORUM AN. EST NE MAGNA PRIMIS
+ADOLESCENS.
+
+. FUSCE EUISMOD COMMODO VELIT.
+. VIVAMUS FRINGILLA MI EU LACUS.
+  .. FUSCE EUISMOD COMMODO VELIT.
+  .. VIVAMUS FRINGILLA MI EU LACUS.
+. DONEC EGET ARCU BIBENDUM NUNC CONSEQUAT LOBORTIS.
+=====================================================================
+
+FILTER BLOCKS
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+This is a Filter block.
+This is a Filter block.
+
+  This is a Filter block.
+  This is a Filter block.
+
+  - This is a Filter block.
+    This is a Filter block.
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+
+
+++++++++++++++++++++++++++
+TEST
+
+--------------------------
+LISTING INSIDE PASSTHROUGH
+--------------------------
+
+END OF TEST
+++++++++++++++++++++++++++
+
+--------------------------
+TEST
+
+__________________________
+QUOTEBLOCK INSIDE LISTING
+__________________________
+
+END OF TEST
+--------------------------
+
+----
+TEST
+
+-------------------------------
+LISTING INSIDE A LISTING
+-------------------------------
+
+END OF TEST
+----


### PR DESCRIPTION
If a block contains a line of the same kind of characters but of
different length, this line is interpreted as a closing fence, just
like python asciidoc.

This is an issue because this means that no such line can be included
in a block. Asciidoctor solves that issue by requiring the opening and
closing fences to be the same length, which can be chosen arbitrarily
greater than 3.

The strict option makes the same test.

Fixes #239