### PR TITLE
Make the Yaml module follow the reference style of YAML Front Matter in Markdown module

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,10 @@ __   __/ _ \ / /_|___ /
 Texinfo:
  * Add support for @tindex (Github's #284)
 
+Yaml:
+ * Follow the reference style of YAML Front Matter in Markdown module to
+   fix the GitHub issue #289. (GitHub's #292)
+
 Build scripts:
  * Fix Po4aBuilder to use -I instead of reseting PERL5LIB (Github's #286)
 

--- a/t/cfg-split.t
+++ b/t/cfg-split.t
@@ -91,6 +91,13 @@ push @tests, {
     'closed_path'    => 'cfg/*/',
     'expected_files' => 'first.man.de first.man.de.po first.man.fr first.man.fr.po first.man.pot '
       . 'second.man.de second.man.de.po second.man.fr second.man.fr.po second.man.pot',
+  },
+  {
+    'doc'            => 'Split settings, with an YAML master doc, translation uptodate',
+    'po4a.conf'      => 'cfg/split-yaml/po4a.cfg',
+    'closed_path'    => 'cfg/*/',
+    'expected_files' => 'content.pot content.vi.po _index.vi.md '
+      . 'i18n.pot i18n.vi.po vi.yaml'
   };
 
 run_all_tests(@tests);

--- a/t/cfg/split-yaml/_index.md
+++ b/t/cfg/split-yaml/_index.md
@@ -1,0 +1,3 @@
+Happy birthday.
+
+Happy new year. 

--- a/t/cfg/split-yaml/_index.vi.md
+++ b/t/cfg/split-yaml/_index.vi.md
@@ -1,0 +1,3 @@
+Chúc mừng sinh nhật.
+
+Chúc mừng năm mới.

--- a/t/cfg/split-yaml/_output
+++ b/t/cfg/split-yaml/_output
@@ -1,0 +1,4 @@
+Split mode, creating a temporary POT: (5 entries)
+Updating the translation in language vi: 5 translated messages.
+_index.vi.md is 100% translated (2 strings).
+vi.yaml is 100% translated (3 strings).

--- a/t/cfg/split-yaml/content.pot
+++ b/t/cfg/split-yaml/content.pot
@@ -7,17 +7,21 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-02-08 08:17+0100\n"
+"POT-Creation-Date: 2021-02-08 09:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: Hash Value: title
-#: skiparray.yaml:0
-#, no-wrap
-msgid "Fedora Project"
+#. type: Plain text
+#: _index.md:2
+msgid "Happy birthday."
+msgstr ""
+
+#. type: Plain text
+#: _index.md:3
+msgid "Happy new year."
 msgstr ""

--- a/t/cfg/split-yaml/content.vi.po
+++ b/t/cfg/split-yaml/content.vi.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-02-08 08:17+0100\n"
+"POT-Creation-Date: 2021-02-08 09:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,8 +16,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: Hash Value: title
-#: skiparray.yaml:0
-#, no-wrap
-msgid "Fedora Project"
-msgstr ""
+#. type: Plain text
+#: _index.md:2
+msgid "Happy birthday."
+msgstr "Chúc mừng sinh nhật."
+
+#. type: Plain text
+#: _index.md:3
+msgid "Happy new year."
+msgstr "Chúc mừng năm mới."

--- a/t/cfg/split-yaml/en.yaml
+++ b/t/cfg/split-yaml/en.yaml
@@ -1,0 +1,6 @@
+translated-by:
+  other: 'Translated by'
+translations:
+  other: Languages
+select-your-language:
+  other: 'Select your language' 

--- a/t/cfg/split-yaml/i18n.pot
+++ b/t/cfg/split-yaml/i18n.pot
@@ -7,17 +7,29 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-02-08 08:17+0100\n"
+"POT-Creation-Date: 2021-02-08 09:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: Hash Value: title
-#: skiparray.yaml:0
+#. type: Hash Value: select-your-language other
+#: en.yaml:0
 #, no-wrap
-msgid "Fedora Project"
+msgid "Select your language"
+msgstr ""
+
+#. type: Hash Value: translated-by other
+#: en.yaml:0
+#, no-wrap
+msgid "Translated by"
+msgstr ""
+
+#. type: Hash Value: translations other
+#: en.yaml:0
+#, no-wrap
+msgid "Languages"
 msgstr ""

--- a/t/cfg/split-yaml/i18n.vi.po
+++ b/t/cfg/split-yaml/i18n.vi.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-02-08 08:17+0100\n"
+"POT-Creation-Date: 2021-02-08 09:08+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,8 +16,20 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: Hash Value: title
-#: skiparray.yaml:0
+#. type: Hash Value: select-your-language other
+#: en.yaml:0
 #, no-wrap
-msgid "Fedora Project"
-msgstr ""
+msgid "Select your language"
+msgstr "Chọn ngôn ngữ"
+
+#. type: Hash Value: translated-by other
+#: en.yaml:0
+#, no-wrap
+msgid "Translated by"
+msgstr "Dịch bởi"
+
+#. type: Hash Value: translations other
+#: en.yaml:0
+#, no-wrap
+msgid "Languages"
+msgstr "Ngôn ngữ"

--- a/t/cfg/split-yaml/po4a.cfg
+++ b/t/cfg/split-yaml/po4a.cfg
@@ -1,0 +1,5 @@
+[po4a_langs] vi
+[po4a_paths] $master.pot $lang:$master.$lang.po
+[type: text] _index.md $lang:_index.$lang.md master:file=content opt:"-o markdown"
+[type: yaml] en.yaml $lang:$lang.yaml master:file=i18n
+[options] -M utf-8 -L utf-8  

--- a/t/cfg/split-yaml/vi.yaml
+++ b/t/cfg/split-yaml/vi.yaml
@@ -1,0 +1,7 @@
+---
+select-your-language:
+  other: 'Chọn ngôn ngữ'
+translated-by:
+  other: 'Dịch bởi'
+translations:
+  other: 'Ngôn ngữ'

--- a/t/fmt/yaml/basic.po
+++ b/t/fmt/yaml/basic.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-05-25 08:00+0000\n"
+"POT-Creation-Date: 2021-02-08 08:12+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,258 +16,260 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: Hash Value - Key: Dir
+#. type: Hash Value: Dir
+#: basic.yaml:0
 #, no-wrap
 msgid "en-US"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>
+#. type: Hash Value: Level1 File
+#: basic.yaml:0
 #, no-wrap
 msgid "index"
 msgstr "INDEX"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Book Information"
 msgstr "BOOK INFORMATION"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Preface"
 msgstr "PREFACE"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Introduction"
 msgstr "INTRODUCTION"
 
-#. type: Hash Value - Key: File
-#: >Level1>
+#. type: Hash Value: Level1 File
+#: basic.yaml:0
 #, no-wrap
 msgid "Downloading_Fedora"
 msgstr "DOWNLOADING_FEDORA"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Downloading Fedora"
 msgstr "DOWNLOADING FEDORA"
 
-#. type: Hash Value - Key: Dir
-#: >Level1>
+#. type: Hash Value: Level1 Dir
+#: basic.yaml:0
 #, no-wrap
 msgid "install"
 msgstr "INSTALL"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a File
+#: basic.yaml:0
 #, no-wrap
 msgid "Preparing_for_Installation"
 msgstr "PREPARING_FOR_INSTALLATION"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Preparing for Installation"
 msgstr "PREPARING FOR INSTALLATION"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a File
+#: basic.yaml:0
 #, no-wrap
 msgid "Booting_the_Installation"
 msgstr "BOOTING_THE_INSTALLATION"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Booting the Installation"
 msgstr "BOOTING THE INSTALLATION"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a File
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing_Using_Anaconda"
 msgstr "INSTALLING USING ANACONDA"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing Using Anaconda"
 msgstr "INSTALLING USING ANACONDA"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a File
+#: basic.yaml:0
 #, no-wrap
 msgid "After_Installation"
 msgstr "AFTER_INSTALLATION"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "After the Installation"
 msgstr "AFTER THE INSTALLATION"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Troubleshooting"
 msgstr "TROUBLESHOOTING"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing Fedora"
 msgstr "INSTALLING FEDORA"
 
-#. type: Hash Value - Key: Dir
-#: >Level1>
+#. type: Hash Value: Level1 Dir
+#: basic.yaml:0
 #, no-wrap
 msgid "advanced"
 msgstr "ADVANCED"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "Boot_Options"
 msgstr "BOOT_OPTIONS"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Boot Options"
 msgstr "BOOT OPTIONS"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "Kickstart_Installations"
 msgstr "KICKSTART_INSTALLATIONS"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Automating the Installation with Kickstart"
 msgstr "AUTOMATING THE INSTALLATION WITH KICKSTART"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "Network_based_Installations"
 msgstr "NETWORK_BASED_INSTALLATIONS"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Setting Up an Installation Server"
 msgstr "SETTING UP AN INSTALLATION SERVER"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "VNC_Installations"
 msgstr "VNC_INSTALLATIONS"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing Using VNC"
 msgstr "INSTALLING USING VNC"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "Upgrading_Your_Current_System"
 msgstr "UPGRADING_YOUR_CURRENT_SYSTEM"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Upgrading Your Current System"
 msgstr "UPGRADING YOUR CURRENT SYSTEM"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Advanced Installation Options"
 msgstr "ADVANCED INSTALLATION OPTIONS"
 
-#. type: Hash Value - Key: Dir
-#: >Level1>
+#. type: Hash Value: Level1 Dir
+#: basic.yaml:0
 #, no-wrap
 msgid "appendixes"
 msgstr "APPENDIXES"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c File
+#: basic.yaml:0
 #, no-wrap
 msgid "Kickstart_Syntax_Reference"
 msgstr "KICKSTART_SYNTAX_REFERENCE"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Kickstart Syntax Reference"
 msgstr "KICKSTART SYNTAX REFERENCE"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c File
+#: basic.yaml:0
 #, no-wrap
 msgid "Disk_Partitions"
 msgstr "DISK_PARTITIONS"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
 #, no-wrap
 msgid "An Introduction to Disk Partitions"
 msgstr "AN INTRODUCTION TO DISK PARTITIONS"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c File
+#: basic.yaml:0
 #, no-wrap
 msgid "Understanding_LVM"
 msgstr "UNDERSTANDING_LVM"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Understanding LVM"
 msgstr "UNDERSTANDING LVM"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Technical Appendixes"
 msgstr "TECHNICAL APPENDIXES"
 
-#. type: Hash Value - Key: File
-#: >Level1>
+#. type: Hash Value: Level1 File
+#: basic.yaml:0
 #, no-wrap
 msgid "Revision_History"
 msgstr "REVISION_HISTORY"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Revision History"
 msgstr "REVISION HISTORY"
 
-#. type: Hash Value - Key: Name
+#. type: Hash Value: Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Fedora Installation Guide"
 msgstr "FEDORA INSTALLATION GUIDE"
 
-#. type: Hash Value - Key: city
-#: >bill-to>address
+#. type: Hash Value: bill-to address city
+#: basic.yaml:0
 #, no-wrap
 msgid "Royal Oak"
 msgstr "ROYAL OAK"
 
-#. type: Hash Value - Key: lines
-#: >bill-to>address
+#. type: Hash Value: bill-to address lines
+#: basic.yaml:0
 #, no-wrap
 msgid ""
 "458 Walkman Dr.\n"
@@ -276,119 +278,128 @@ msgstr ""
 "458 WALKMAN DR.\n"
 "SUITE #292\n"
 
-#. type: Hash Value - Key: postal
-#: >bill-to>address
+#. type: Hash Value: bill-to address postal
+#: basic.yaml:0
 #, no-wrap
 msgid "48046"
 msgstr "48046"
 
-#. type: Hash Value - Key: state
-#: >bill-to>address
+#. type: Hash Value: bill-to address state
+#: basic.yaml:0
 #, no-wrap
 msgid "MI"
 msgstr "MI"
 
-#. type: Hash Value - Key: family
-#: >bill-to
+#. type: Hash Value: bill-to family
+#: basic.yaml:0
 #, no-wrap
 msgid "Dumars"
 msgstr "DUMARS"
 
-#. type: Hash Value - Key: given
-#: >bill-to
+#. type: Hash Value: bill-to given
+#: basic.yaml:0
 #, no-wrap
 msgid "Chris"
 msgstr "CHRIS"
 
-#. type: Hash Value - Key: date
+#. type: Hash Value: date
+#: basic.yaml:0
 #, no-wrap
 msgid "2001-01-23"
 msgstr "2001-01-23"
 
-#. type: Hash Value - Key: invoice
+#. type: Hash Value: invoice
+#: basic.yaml:0
 #, no-wrap
 msgid "34843"
 msgstr "34843"
 
-#. type: Hash Value - Key: description
-#: >product>
+#. type: Hash Value: product description
+#: basic.yaml:0
 #, no-wrap
 msgid "Basketball"
 msgstr "BASKETBALL"
 
-#. type: Hash Value - Key: price
-#: >product>
+#. type: Hash Value: product price
+#: basic.yaml:0
 #, no-wrap
 msgid "450.00"
 msgstr ""
 
-#. type: Hash Value - Key: quantity
-#: >product>
+#. type: Hash Value: product quantity
+#: basic.yaml:0
 #, no-wrap
 msgid "4"
 msgstr ""
 
-#. type: Hash Value - Key: sku
-#: >product>
+#. type: Hash Value: product sku
+#: basic.yaml:0
 #, no-wrap
 msgid "BL394D"
 msgstr ""
 
-#. type: Hash Value - Key: description
-#: >product>
+#. type: Hash Value: product description
+#: basic.yaml:0
 #, no-wrap
 msgid "Super Hoop"
 msgstr "SUPER HOOP"
 
-#. type: Hash Value - Key: price
-#: >product>
+#. type: Hash Value: product price
+#: basic.yaml:0
 #, no-wrap
 msgid "2392.00"
 msgstr ""
 
-#. type: Hash Value - Key: quantity
-#: >product>
+#. type: Hash Value: product quantity
+#: basic.yaml:0
 #, no-wrap
 msgid "1"
 msgstr ""
 
-#. type: Hash Value - Key: sku
-#: >product>
+#. type: Hash Value: product sku
+#: basic.yaml:0
 #, no-wrap
 msgid "BL4438H"
 msgstr ""
 
-#. type: Hash Value - Key: tax
+#. type: Hash Value: tax
+#: basic.yaml:0
 #, no-wrap
 msgid "251.42"
 msgstr ""
 
-#. type: Hash Value - Key: total
+#. type: Hash Value: total
+#: basic.yaml:0
 #, no-wrap
 msgid "4443.52"
 msgstr ""
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Mark McGwire"
 msgstr "MARK MCGWIRE"
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Sammy Sosa"
 msgstr "SAMMY SOSA"
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Ken Griffey"
 msgstr "KEN GRIFFEY"
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Chicago Cubs"
 msgstr "CHICAGO CUBS"
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "St Louis Cardinals"
 msgstr "ST LOUIS CARDINALS"

--- a/t/fmt/yaml/basic.pot
+++ b/t/fmt/yaml/basic.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-05-25 08:00+0000\n"
+"POT-Creation-Date: 2021-02-08 08:12+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,377 +16,388 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: Hash Value - Key: Dir
+#. type: Hash Value: Dir
+#: basic.yaml:0
 #, no-wrap
 msgid "en-US"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>
+#. type: Hash Value: Level1 File
+#: basic.yaml:0
 #, no-wrap
 msgid "index"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Book Information"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Preface"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Introduction"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>
+#. type: Hash Value: Level1 File
+#: basic.yaml:0
 #, no-wrap
 msgid "Downloading_Fedora"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Downloading Fedora"
 msgstr ""
 
-#. type: Hash Value - Key: Dir
-#: >Level1>
+#. type: Hash Value: Level1 Dir
+#: basic.yaml:0
 #, no-wrap
 msgid "install"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a File
+#: basic.yaml:0
 #, no-wrap
 msgid "Preparing_for_Installation"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Preparing for Installation"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a File
+#: basic.yaml:0
 #, no-wrap
 msgid "Booting_the_Installation"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Booting the Installation"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a File
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing_Using_Anaconda"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing Using Anaconda"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a File
+#: basic.yaml:0
 #, no-wrap
 msgid "After_Installation"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "After the Installation"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing Fedora"
 msgstr ""
 
-#. type: Hash Value - Key: Dir
-#: >Level1>
+#. type: Hash Value: Level1 Dir
+#: basic.yaml:0
 #, no-wrap
 msgid "advanced"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "Boot_Options"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Boot Options"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "Kickstart_Installations"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Automating the Installation with Kickstart"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "Network_based_Installations"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Setting Up an Installation Server"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "VNC_Installations"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing Using VNC"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "Upgrading_Your_Current_System"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Upgrading Your Current System"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Advanced Installation Options"
 msgstr ""
 
-#. type: Hash Value - Key: Dir
-#: >Level1>
+#. type: Hash Value: Level1 Dir
+#: basic.yaml:0
 #, no-wrap
 msgid "appendixes"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c File
+#: basic.yaml:0
 #, no-wrap
 msgid "Kickstart_Syntax_Reference"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Kickstart Syntax Reference"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c File
+#: basic.yaml:0
 #, no-wrap
 msgid "Disk_Partitions"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
 #, no-wrap
 msgid "An Introduction to Disk Partitions"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c File
+#: basic.yaml:0
 #, no-wrap
 msgid "Understanding_LVM"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Understanding LVM"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Technical Appendixes"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>
+#. type: Hash Value: Level1 File
+#: basic.yaml:0
 #, no-wrap
 msgid "Revision_History"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Revision History"
 msgstr ""
 
-#. type: Hash Value - Key: Name
+#. type: Hash Value: Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Fedora Installation Guide"
 msgstr ""
 
-#. type: Hash Value - Key: city
-#: >bill-to>address
+#. type: Hash Value: bill-to address city
+#: basic.yaml:0
 #, no-wrap
 msgid "Royal Oak"
 msgstr ""
 
-#. type: Hash Value - Key: lines
-#: >bill-to>address
+#. type: Hash Value: bill-to address lines
+#: basic.yaml:0
 #, no-wrap
 msgid ""
 "458 Walkman Dr.\n"
 "Suite #292\n"
 msgstr ""
 
-#. type: Hash Value - Key: postal
-#: >bill-to>address
+#. type: Hash Value: bill-to address postal
+#: basic.yaml:0
 #, no-wrap
 msgid "48046"
 msgstr ""
 
-#. type: Hash Value - Key: state
-#: >bill-to>address
+#. type: Hash Value: bill-to address state
+#: basic.yaml:0
 #, no-wrap
 msgid "MI"
 msgstr ""
 
-#. type: Hash Value - Key: family
-#: >bill-to
+#. type: Hash Value: bill-to family
+#: basic.yaml:0
 #, no-wrap
 msgid "Dumars"
 msgstr ""
 
-#. type: Hash Value - Key: given
-#: >bill-to
+#. type: Hash Value: bill-to given
+#: basic.yaml:0
 #, no-wrap
 msgid "Chris"
 msgstr ""
 
-#. type: Hash Value - Key: date
+#. type: Hash Value: date
+#: basic.yaml:0
 #, no-wrap
 msgid "2001-01-23"
 msgstr ""
 
-#. type: Hash Value - Key: invoice
+#. type: Hash Value: invoice
+#: basic.yaml:0
 #, no-wrap
 msgid "34843"
 msgstr ""
 
-#. type: Hash Value - Key: description
-#: >product>
+#. type: Hash Value: product description
+#: basic.yaml:0
 #, no-wrap
 msgid "Basketball"
 msgstr ""
 
-#. type: Hash Value - Key: price
-#: >product>
+#. type: Hash Value: product price
+#: basic.yaml:0
 #, no-wrap
 msgid "450.00"
 msgstr ""
 
-#. type: Hash Value - Key: quantity
-#: >product>
+#. type: Hash Value: product quantity
+#: basic.yaml:0
 #, no-wrap
 msgid "4"
 msgstr ""
 
-#. type: Hash Value - Key: sku
-#: >product>
+#. type: Hash Value: product sku
+#: basic.yaml:0
 #, no-wrap
 msgid "BL394D"
 msgstr ""
 
-#. type: Hash Value - Key: description
-#: >product>
+#. type: Hash Value: product description
+#: basic.yaml:0
 #, no-wrap
 msgid "Super Hoop"
 msgstr ""
 
-#. type: Hash Value - Key: price
-#: >product>
+#. type: Hash Value: product price
+#: basic.yaml:0
 #, no-wrap
 msgid "2392.00"
 msgstr ""
 
-#. type: Hash Value - Key: quantity
-#: >product>
+#. type: Hash Value: product quantity
+#: basic.yaml:0
 #, no-wrap
 msgid "1"
 msgstr ""
 
-#. type: Hash Value - Key: sku
-#: >product>
+#. type: Hash Value: product sku
+#: basic.yaml:0
 #, no-wrap
 msgid "BL4438H"
 msgstr ""
 
-#. type: Hash Value - Key: tax
+#. type: Hash Value: tax
+#: basic.yaml:0
 #, no-wrap
 msgid "251.42"
 msgstr ""
 
-#. type: Hash Value - Key: total
+#. type: Hash Value: total
+#: basic.yaml:0
 #, no-wrap
 msgid "4443.52"
 msgstr ""
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Mark McGwire"
 msgstr ""
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Sammy Sosa"
 msgstr ""
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Ken Griffey"
 msgstr ""
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Chicago Cubs"
 msgstr ""
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "St Louis Cardinals"
 msgstr ""

--- a/t/fmt/yaml/keysoption1.po
+++ b/t/fmt/yaml/keysoption1.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-05-25 08:00+0000\n"
+"POT-Creation-Date: 2021-02-08 08:15+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,158 +16,164 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Book Information"
 msgstr "BOOK INFORMATION"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Preface"
 msgstr "PREFACE"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Introduction"
 msgstr "INTRODUCTION"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Downloading Fedora"
 msgstr "DOWNLOADING FEDORA"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Preparing for Installation"
 msgstr "PREPARING FOR INSTALLATION"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Booting the Installation"
 msgstr "BOOTING THE INSTALLATION"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing Using Anaconda"
 msgstr "INSTALLING USING ANACONDA"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "After the Installation"
 msgstr "AFTER THE INSTALLATION"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Troubleshooting"
 msgstr "TROUBLESHOOTING"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing Fedora"
 msgstr "INSTALLING FEDORA"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Boot Options"
 msgstr "BOOT OPTIONS"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Automating the Installation with Kickstart"
 msgstr "AUTOMATING THE INSTALLATION WITH KICKSTART"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Setting Up an Installation Server"
 msgstr "SETTING UP AN INSTALLATION SERVER"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing Using VNC"
 msgstr "INSTALLING USING VNC"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Upgrading Your Current System"
 msgstr "UPGRADING YOUR CURRENT SYSTEM"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Advanced Installation Options"
 msgstr "ADVANCED INSTALLATION OPTIONS"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Kickstart Syntax Reference"
 msgstr "KICKSTART SYNTAX REFERENCE"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
 #, no-wrap
 msgid "An Introduction to Disk Partitions"
 msgstr "AN INTRODUCTION TO DISK PARTITIONS"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Understanding LVM"
 msgstr "UNDERSTANDING LVM"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Technical Appendixes"
 msgstr "TECHNICAL APPENDIXES"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Revision History"
 msgstr "REVISION HISTORY"
 
-#. type: Hash Value - Key: Name
+#. type: Hash Value: Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Fedora Installation Guide"
 msgstr "FEDORA INSTALLATION GUIDE"
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Mark McGwire"
 msgstr "MARK MCGWIRE"
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Sammy Sosa"
 msgstr "SAMMY SOSA"
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Ken Griffey"
 msgstr "KEN GRIFFEY"
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Chicago Cubs"
 msgstr "CHICAGO CUBS"
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "St Louis Cardinals"
 msgstr "ST LOUIS CARDINALS"

--- a/t/fmt/yaml/keysoption1.pot
+++ b/t/fmt/yaml/keysoption1.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-05-25 08:00+0000\n"
+"POT-Creation-Date: 2021-02-08 08:15+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,158 +16,164 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Book Information"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Preface"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Introduction"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Downloading Fedora"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Preparing for Installation"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Booting the Installation"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing Using Anaconda"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "After the Installation"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing Fedora"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Boot Options"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Automating the Installation with Kickstart"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Setting Up an Installation Server"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing Using VNC"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Upgrading Your Current System"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Advanced Installation Options"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Kickstart Syntax Reference"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
 #, no-wrap
 msgid "An Introduction to Disk Partitions"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Understanding LVM"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Technical Appendixes"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Revision History"
 msgstr ""
 
-#. type: Hash Value - Key: Name
+#. type: Hash Value: Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Fedora Installation Guide"
 msgstr ""
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Mark McGwire"
 msgstr ""
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Sammy Sosa"
 msgstr ""
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Ken Griffey"
 msgstr ""
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Chicago Cubs"
 msgstr ""
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "St Louis Cardinals"
 msgstr ""

--- a/t/fmt/yaml/keysoption2.po
+++ b/t/fmt/yaml/keysoption2.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-04-26 00:13+0200\n"
+"POT-Creation-Date: 2021-02-08 08:16+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,248 +16,254 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: Hash Value - Key: File
-#: >Level1>
+#. type: Hash Value: Level1 File
+#: basic.yaml:0
 #, no-wrap
 msgid "index"
 msgstr "INDEX"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Book Information"
 msgstr "BOOK INFORMATION"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Preface"
 msgstr "PREFACE"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Introduction"
 msgstr "INTRODUCTION"
 
-#. type: Hash Value - Key: File
-#: >Level1>
+#. type: Hash Value: Level1 File
+#: basic.yaml:0
 #, no-wrap
 msgid "Downloading_Fedora"
 msgstr "DOWNLOADING_FEDORA"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Downloading Fedora"
 msgstr "DOWNLOADING FEDORA"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a File
+#: basic.yaml:0
 #, no-wrap
 msgid "Preparing_for_Installation"
 msgstr "PREPARING_FOR_INSTALLATION"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Preparing for Installation"
 msgstr "PREPARING FOR INSTALLATION"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a File
+#: basic.yaml:0
 #, no-wrap
 msgid "Booting_the_Installation"
 msgstr "BOOTING_THE_INSTALLATION"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Booting the Installation"
 msgstr "BOOTING THE INSTALLATION"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a File
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing_Using_Anaconda"
 msgstr "INSTALLING USING ANACONDA"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing Using Anaconda"
 msgstr "INSTALLING USING ANACONDA"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a File
+#: basic.yaml:0
 #, no-wrap
 msgid "After_Installation"
 msgstr "AFTER_INSTALLATION"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "After the Installation"
 msgstr "AFTER THE INSTALLATION"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Troubleshooting"
 msgstr "TROUBLESHOOTING"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing Fedora"
 msgstr "INSTALLING FEDORA"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "Boot_Options"
 msgstr "BOOT_OPTIONS"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Boot Options"
 msgstr "BOOT OPTIONS"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "Kickstart_Installations"
 msgstr "KICKSTART_INSTALLATIONS"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Automating the Installation with Kickstart"
 msgstr "AUTOMATING THE INSTALLATION WITH KICKSTART"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "Network_based_Installations"
 msgstr "NETWORK_BASED_INSTALLATIONS"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Setting Up an Installation Server"
 msgstr "SETTING UP AN INSTALLATION SERVER"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "VNC_Installations"
 msgstr "VNC_INSTALLATIONS"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing Using VNC"
 msgstr "INSTALLING USING VNC"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "Upgrading_Your_Current_System"
 msgstr "UPGRADING_YOUR_CURRENT_SYSTEM"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Upgrading Your Current System"
 msgstr "UPGRADING YOUR CURRENT SYSTEM"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Advanced Installation Options"
 msgstr "ADVANCED INSTALLATION OPTIONS"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c File
+#: basic.yaml:0
 #, no-wrap
 msgid "Kickstart_Syntax_Reference"
 msgstr "KICKSTART_SYNTAX_REFERENCE"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Kickstart Syntax Reference"
 msgstr "KICKSTART SYNTAX REFERENCE"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c File
+#: basic.yaml:0
 #, no-wrap
 msgid "Disk_Partitions"
 msgstr "DISK_PARTITIONS"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
 #, no-wrap
 msgid "An Introduction to Disk Partitions"
 msgstr "AN INTRODUCTION TO DISK PARTITIONS"
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c File
+#: basic.yaml:0
 #, no-wrap
 msgid "Understanding_LVM"
 msgstr "UNDERSTANDING_LVM"
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Understanding LVM"
 msgstr "UNDERSTANDING LVM"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Technical Appendixes"
 msgstr "TECHNICAL APPENDIXES"
 
-#. type: Hash Value - Key: File
-#: >Level1>
+#. type: Hash Value: Level1 File
+#: basic.yaml:0
 #, no-wrap
 msgid "Revision_History"
 msgstr "REVISION_HISTORY"
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Revision History"
 msgstr "REVISION HISTORY"
 
-#. type: Hash Value - Key: Name
+#. type: Hash Value: Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Fedora Installation Guide"
 msgstr "FEDORA INSTALLATION GUIDE"
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Mark McGwire"
 msgstr "MARK MCGWIRE"
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Sammy Sosa"
 msgstr "SAMMY SOSA"
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Ken Griffey"
 msgstr "KEN GRIFFEY"
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Chicago Cubs"
 msgstr "CHICAGO CUBS"
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "St Louis Cardinals"
 msgstr "ST LOUIS CARDINALS"

--- a/t/fmt/yaml/keysoption2.pot
+++ b/t/fmt/yaml/keysoption2.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-04-26 00:13+0200\n"
+"POT-Creation-Date: 2021-02-08 08:16+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,248 +16,254 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: Hash Value - Key: File
-#: >Level1>
+#. type: Hash Value: Level1 File
+#: basic.yaml:0
 #, no-wrap
 msgid "index"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Book Information"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Preface"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Introduction"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>
+#. type: Hash Value: Level1 File
+#: basic.yaml:0
 #, no-wrap
 msgid "Downloading_Fedora"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Downloading Fedora"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a File
+#: basic.yaml:0
 #, no-wrap
 msgid "Preparing_for_Installation"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Preparing for Installation"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a File
+#: basic.yaml:0
 #, no-wrap
 msgid "Booting_the_Installation"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Booting the Installation"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a File
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing_Using_Anaconda"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing Using Anaconda"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a File
+#: basic.yaml:0
 #, no-wrap
 msgid "After_Installation"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "After the Installation"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-a>
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing Fedora"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "Boot_Options"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Boot Options"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "Kickstart_Installations"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Automating the Installation with Kickstart"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "Network_based_Installations"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Setting Up an Installation Server"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "VNC_Installations"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Installing Using VNC"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b File
+#: basic.yaml:0
 #, no-wrap
 msgid "Upgrading_Your_Current_System"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-b>
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Upgrading Your Current System"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Advanced Installation Options"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c File
+#: basic.yaml:0
 #, no-wrap
 msgid "Kickstart_Syntax_Reference"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Kickstart Syntax Reference"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c File
+#: basic.yaml:0
 #, no-wrap
 msgid "Disk_Partitions"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
 #, no-wrap
 msgid "An Introduction to Disk Partitions"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c File
+#: basic.yaml:0
 #, no-wrap
 msgid "Understanding_LVM"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>>Level2-c>
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Understanding LVM"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Technical Appendixes"
 msgstr ""
 
-#. type: Hash Value - Key: File
-#: >Level1>
+#. type: Hash Value: Level1 File
+#: basic.yaml:0
 #, no-wrap
 msgid "Revision_History"
 msgstr ""
 
-#. type: Hash Value - Key: Name
-#: >Level1>
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Revision History"
 msgstr ""
 
-#. type: Hash Value - Key: Name
+#. type: Hash Value: Name
+#: basic.yaml:0
 #, no-wrap
 msgid "Fedora Installation Guide"
 msgstr ""
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Mark McGwire"
 msgstr ""
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Sammy Sosa"
 msgstr ""
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Ken Griffey"
 msgstr ""
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "Chicago Cubs"
 msgstr ""
 
-#. type: Array Element
+#. type: Array Element:
+#: basic.yaml:0
 #, no-wrap
 msgid "St Louis Cardinals"
 msgstr ""

--- a/t/fmt/yaml/skiparray.po
+++ b/t/fmt/yaml/skiparray.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-11-07 19:08+0100\n"
+"POT-Creation-Date: 2021-02-08 08:17+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: Hash Value - Key: title
+#. type: Hash Value: title
+#: skiparray.yaml:0
 #, no-wrap
 msgid "Fedora Project"
 msgstr "FEDORA PROJECT"

--- a/t/fmt/yaml/utf8.po
+++ b/t/fmt/yaml/utf8.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-05-25 08:00+0000\n"
+"POT-Creation-Date: 2021-02-08 08:18+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,8 +16,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: Hash Value - Key: lang
-#: >meta
+#. type: Hash Value: meta lang
+#: utf8.yaml:0
 #, no-wrap
 msgid "日本語"
 msgstr "UPPER CASE"

--- a/t/fmt/yaml/utf8.pot
+++ b/t/fmt/yaml/utf8.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-05-25 08:00+0000\n"
+"POT-Creation-Date: 2021-02-08 08:18+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,8 +16,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: Hash Value - Key: lang
-#: >meta
+#. type: Hash Value: meta lang
+#: utf8.yaml:0
 #, no-wrap
 msgid "日本語"
 msgstr ""


### PR DESCRIPTION
- Fix #289
Instead of key names, use the file name and line number 0 as the reference. Put key names in the comment for type
- Add a test for the case of split settings with an YAML master doc