### PR TITLE
Asciidoc: Don't split in attributes include:: and ifeval:: lines

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,7 @@ __   __/ _ \ / /_ | || |
 
 Asciidoc:
  * Detect sublevel description lists with :::
+ * Don't split in attributes include:: and ifeval:: lines
 
 Translations:
 Status of the binary translation:

--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -771,6 +771,10 @@ sub parse {
                 and ( defined( $self->{type} ) and ( $self->{type} eq "Table" ) ) )
             {
                 $paragraph .= $line . "\n";
+            } elsif (    ( $macroname eq "include" || $macroname eq "ifeval" )
+                and ( $macrotype eq '::' ) )
+            {
+                $self->pushline( $line . "\n" );
             } else {
                 if ( $macrotype eq '::' ) {
                     do_paragraph( $self, $paragraph, $wrapped_mode );

--- a/t/fmt/asciidoc/StyleMacro.adoc
+++ b/t/fmt/asciidoc/StyleMacro.adoc
@@ -53,3 +53,7 @@ image::foo.png[]
 ifeval::[42 == 42]
 // Empty macro target:
 endif::[]
+
+ifeval::["{foo}" == "bar"]
+include::{foo-path}bar.adoc[leveloffset=+1, lines=7..21;32..-1]
+endif::[]

--- a/t/fmt/asciidoc/StyleMacro.norm
+++ b/t/fmt/asciidoc/StyleMacro.norm
@@ -45,3 +45,7 @@ image::foo.png[]
 
 ifeval::[42 == 42]
 endif::[]
+
+ifeval::["{foo}" == "bar"]
+include::{foo-path}bar.adoc[leveloffset=+1, lines=7..21;32..-1]
+endif::[]

--- a/t/fmt/asciidoc/StyleMacro.pot
+++ b/t/fmt/asciidoc/StyleMacro.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-04-28 11:26+0200\n"
+"POT-Creation-Date: 2021-03-13 16:59-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/t/fmt/asciidoc/StyleMacro.trans
+++ b/t/fmt/asciidoc/StyleMacro.trans
@@ -45,3 +45,7 @@ image::FOO.PNG[]
 
 ifeval::[42 == 42]
 endif::[]
+
+ifeval::["{foo}" == "bar"]
+include::{foo-path}bar.adoc[leveloffset=+1, lines=7..21;32..-1]
+endif::[]


### PR DESCRIPTION
Issue summary:
```
    # | -ifeval::["{foo}" == "bar"]
    # | -include::{foo-path}bar.adoc[leveloffset=+1, lines=7..21;32..-1]
    # | +ifeval::["{foo}",  == "bar"]
    # | +include::{foo-path}bar.adoc[leveloffset=+1,,  lines=7..21;32..-1]
    # |  endif::[]
```

More details in the [maillist post](https://lists.po4a.org/archives/list/devel@lists.po4a.org/thread/NZLXESHZKXCCRM2G2IX7OALS4V2WGVPI/).

First PR here, I'll need someone to review please.

Thanks!