### PR TITLE
Instead of using a regex, use subsbtring matching for flags

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,7 @@ __   __/ _ \ / /_ | || |
 Asciidoc:
  * Detect sublevel description lists with :::
  * Don't split in attributes include:: and ifeval:: lines (Github's #298)
+ * mitigate Perl bug #18604 (Github's #302)
 
 Translations:
  * Updated: Esperanto, thanks phlostically.

--- a/lib/Locale/Po4a/Po.pm
+++ b/lib/Locale/Po4a/Po.pm
@@ -1467,7 +1467,7 @@ sub push_raw {
         $flags = " $flags ";
         $flags =~ s/,/ /g;
         foreach my $flag (@known_flags) {
-            if ( $flags =~ /\s$flag\s/ ) {    # if flag to be set
+			if (index($flags, " $flag ") != -1) {     # if flag to be set
                 unless ( defined( $self->{po}{$msgid}{'flags'} )
                     && $self->{po}{$msgid}{'flags'} =~ /\b$flag\b/ )
                 {


### PR DESCRIPTION
This change mitigates #302 when perl exhibits the bug
https://github.com/Perl/perl5/issues/18604

and seems to speed up flag matching.

fix #302