### PR TITLE
[Yaml] add option to parse only specific Yaml paths

### DIFF
--- a/lib/Locale/Po4a/Yaml.pm
+++ b/lib/Locale/Po4a/Yaml.pm
@@ -89,10 +89,14 @@ sub walk_yaml {
             if ( ref $el->{$key} ne ref "" ) {
                 &walk_yaml( $self, $el->{$key}, "$ctx $key" );
             } else {
-                print STDERR "working on path '$ctx $key'\n" if $self->{'options'}{'debug'};
                 my $path = "$ctx $key" =~ s/^\s+|\s+$//gr;
-                next if (  !(( $self->{options}{keys}  eq "" ) or ( exists $self->{keys}{ lc($key) }   )) or
-                           !(( $self->{options}{paths} eq "" ) or ( exists $self->{paths}{ lc($path) } )) );
+                print STDERR "working on path '$path'\n" if $self->{'options'}{'debug'};
+                my $keysdefined = $self->{options}{keys}  ne "";
+                my $keymatches = exists $self->{keys}{ lc($key) };
+                my $pathsdefined = $self->{options}{paths} ne "";
+                my $pathmatches = exists $self->{paths}{ lc($path) };
+                next if ( !(($keysdefined and $keymatches) or ($pathsdefined and $pathmatches) or (not $keysdefined and not $pathsdefined)));
+                print STDERR " * path survived check\n" if $self->{'options'}{'debug'};
                 my $trans = $self->translate(
                     Encode::encode_utf8( $el->{$key} ),
                     $reference,

--- a/lib/Locale/Po4a/Yaml.pm
+++ b/lib/Locale/Po4a/Yaml.pm
@@ -91,7 +91,7 @@ sub walk_yaml {
             } else {
                 print STDERR "working on path '$ctx $key'\n" if $self->{'options'}{'debug'};
                 my $path = "$ctx $key" =~ s/^\s+|\s+$//gr;
-                next if (  !(( $self->{options}{keys}  eq "" ) or ( exists $self->{keys}{ lc($key) }   )) and
+                next if (  !(( $self->{options}{keys}  eq "" ) or ( exists $self->{keys}{ lc($key) }   )) or
                            !(( $self->{options}{paths} eq "" ) or ( exists $self->{paths}{ lc($path) } )) );
                 my $trans = $self->translate(
                     Encode::encode_utf8( $el->{$key} ),

--- a/lib/Locale/Po4a/Yaml.pm
+++ b/lib/Locale/Po4a/Yaml.pm
@@ -154,7 +154,7 @@ These are this module's particular options:
 Space-separated list of hash keys to process for extraction, all
 other keys are skipped.  Keys are matched with a case-insentive match.
 If B<paths> and B<keys> are used together, values are included if they are
-matched by one of the options.
+matched by at least one of the options.
 Arrays values are always returned unless if the B<skip_array> option is
 provided.
 
@@ -163,7 +163,7 @@ provided.
 Comma-separated list of hash paths to process for extraction, all
 other paths are skipped. Paths are matched with a case-insensitive match.
 If B<paths> and B<keys> are used together, values are included if they are
-matched by one of the options.
+matched by at least one of the options.
 Arrays values are always returned unless if the B<skip_array> option is
 provided.
 

--- a/po/bin/po4a.pot
+++ b/po/bin/po4a.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: po4a 0.66\n"
 "Report-Msgid-Bugs-To: po4a@packages.debian.org\n"
-"POT-Creation-Date: 2021-11-14 13:41+0100\n"
+"POT-Creation-Date: 2021-11-24 15:38+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 #: ../../lib/Locale/Po4a/Po.pm:235 ../../lib/Locale/Po4a/RubyDoc.pm:74
 #: ../../lib/Locale/Po4a/Sgml.pm:258 ../../lib/Locale/Po4a/TeX.pm:1664
 #: ../../lib/Locale/Po4a/Text.pm:211 ../../lib/Locale/Po4a/Xml.pm:598
-#: ../../lib/Locale/Po4a/Yaml.pm:39
+#: ../../lib/Locale/Po4a/Yaml.pm:40
 #, perl-format
 msgid "Unknown option: %s"
 msgstr ""
@@ -42,14 +42,14 @@ msgstr ""
 msgid "Cannot open %s: %s"
 msgstr ""
 
-#: ../../lib/Locale/Po4a/AsciiDoc.pm:365
+#: ../../lib/Locale/Po4a/AsciiDoc.pm:366
 #, perl-format
 msgid ""
 "Detection of two line titles failed at %s\n"
-"Please install the Unicode::GCString module."
+"Please install the Unicode::GCString module (error: %s)."
 msgstr ""
 
-#: ../../lib/Locale/Po4a/AsciiDoc.pm:512
+#: ../../lib/Locale/Po4a/AsciiDoc.pm:513
 #, perl-format
 msgid ""
 "'%s' seems to be a two-lines title underlined with '%s', but the underlines "
@@ -57,7 +57,7 @@ msgid ""
 "your master document."
 msgstr ""
 
-#: ../../lib/Locale/Po4a/AsciiDoc.pm:991
+#: ../../lib/Locale/Po4a/AsciiDoc.pm:992
 msgid ""
 "It seems that you are adding unindented content to an item. The standard "
 "allows this, but you may still want to change your document to use indented "

--- a/t/fmt-yaml.t
+++ b/t/fmt-yaml.t
@@ -43,6 +43,24 @@ push @tests,
     'format'  => 'yaml',
     'options' => "-M UTF-8",
     'input'   => "fmt/yaml/utf8.yaml",
+  },
+  {
+    'doc'     => "basic -o keys='name' -o paths='name,level1 dir,invoice,bill-to address city' -o skip_array",
+    'format'  => 'yaml',
+    'input'   => "fmt/yaml/basic.yaml",
+    'options' => "-o keys='name' -o paths='name,level1 dir,invoice,bill-to address city' -o skip_array",
+    'potfile' => 'fmt/yaml/keysandpaths1.pot',
+    'pofile'  => 'fmt/yaml/keysandpaths1.po',
+    'trans'   => 'fmt/yaml/keysandpaths1.trans',
+  },
+  {
+    'doc'     => "basic -o paths='name,level1 dir ' -o skip_array",
+    'format'  => 'yaml',
+    'input'   => "fmt/yaml/basic.yaml",
+    'options' => "-o paths='name,level1 dir' -o skip_array",
+    'potfile' => 'fmt/yaml/pathsoption1.pot',
+    'pofile'  => 'fmt/yaml/pathsoption1.po',
+    'trans'   => 'fmt/yaml/pathsoption1.trans',
   };
 
 run_all_tests(@tests);

--- a/t/fmt/yaml/keysandpaths1.po
+++ b/t/fmt/yaml/keysandpaths1.po
@@ -1,0 +1,179 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2021-11-24 16:50+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Book Information"
+msgstr "BOOK INFORMATION"
+
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Preface"
+msgstr "PREFACE"
+
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Introduction"
+msgstr "INTRODUCTION"
+
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Downloading Fedora"
+msgstr "DOWNLOADING FEDORA"
+
+#. type: Hash Value: Level1 Dir
+#: basic.yaml:0
+#, no-wrap
+msgid "install"
+msgstr "INSTALL"
+
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Preparing for Installation"
+msgstr "PREPARING FOR INSTALLATION"
+
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Booting the Installation"
+msgstr "BOOTING THE INSTALLATION"
+
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Installing Using Anaconda"
+msgstr "INSTALLING USING ANACONDA"
+
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
+#, no-wrap
+msgid "After the Installation"
+msgstr "AFTER THE INSTALLATION"
+
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Troubleshooting"
+msgstr "TROUBLESHOOTING"
+
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Installing Fedora"
+msgstr "INSTALLING FEDORA"
+
+#. type: Hash Value: Level1 Dir
+#: basic.yaml:0
+#, no-wrap
+msgid "advanced"
+msgstr "ADVANCED"
+
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Boot Options"
+msgstr "BOOT OPTIONS"
+
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Automating the Installation with Kickstart"
+msgstr "AUTOMATING THE INSTALLATION WITH KICKSTART"
+
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Setting Up an Installation Server"
+msgstr "SETTING UP AN INSTALLATION SERVER"
+
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Installing Using VNC"
+msgstr "INSTALLING USING VNC"
+
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Upgrading Your Current System"
+msgstr "UPGRAINDG YOUR CURRENT SYSTEM"
+
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Advanced Installation Options"
+msgstr "ADVANCED INSTALLATION OPTIONS"
+
+#. type: Hash Value: Level1 Dir
+#: basic.yaml:0
+#, no-wrap
+msgid "appendixes"
+msgstr "APPENDIXES"
+
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Kickstart Syntax Reference"
+msgstr "KICKSTART SYNTAX REFERENCE"
+
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
+#, no-wrap
+msgid "An Introduction to Disk Partitions"
+msgstr "AN INTRODUCTION TO DISK PARTITIONS"
+
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Understanding LVM"
+msgstr "UNDERSTANDING LVM"
+
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Technical Appendixes"
+msgstr "TECHNICAL APPENDIXES"
+
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Revision History"
+msgstr "REVISION HISTORY"
+
+#. type: Hash Value: Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Fedora Installation Guide"
+msgstr "FEDORA INSTALLATION GUIDE"
+
+#. type: Hash Value: bill-to address city
+#: basic.yaml:0
+#, no-wrap
+msgid "Royal Oak"
+msgstr "ROYAL OAK"
+
+#. type: Hash Value: invoice
+#: basic.yaml:0
+#, no-wrap
+msgid "34843"
+msgstr "#34843#"

--- a/t/fmt/yaml/keysandpaths1.pot
+++ b/t/fmt/yaml/keysandpaths1.pot
@@ -1,0 +1,179 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2021-11-24 19:05+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Book Information"
+msgstr ""
+
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Preface"
+msgstr ""
+
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Introduction"
+msgstr ""
+
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Downloading Fedora"
+msgstr ""
+
+#. type: Hash Value: Level1 Dir
+#: basic.yaml:0
+#, no-wrap
+msgid "install"
+msgstr ""
+
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Preparing for Installation"
+msgstr ""
+
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Booting the Installation"
+msgstr ""
+
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Installing Using Anaconda"
+msgstr ""
+
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
+#, no-wrap
+msgid "After the Installation"
+msgstr ""
+
+#. type: Hash Value: Level1 Level2-a Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Troubleshooting"
+msgstr ""
+
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Installing Fedora"
+msgstr ""
+
+#. type: Hash Value: Level1 Dir
+#: basic.yaml:0
+#, no-wrap
+msgid "advanced"
+msgstr ""
+
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Boot Options"
+msgstr ""
+
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Automating the Installation with Kickstart"
+msgstr ""
+
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Setting Up an Installation Server"
+msgstr ""
+
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Installing Using VNC"
+msgstr ""
+
+#. type: Hash Value: Level1 Level2-b Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Upgrading Your Current System"
+msgstr ""
+
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Advanced Installation Options"
+msgstr ""
+
+#. type: Hash Value: Level1 Dir
+#: basic.yaml:0
+#, no-wrap
+msgid "appendixes"
+msgstr ""
+
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Kickstart Syntax Reference"
+msgstr ""
+
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
+#, no-wrap
+msgid "An Introduction to Disk Partitions"
+msgstr ""
+
+#. type: Hash Value: Level1 Level2-c Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Understanding LVM"
+msgstr ""
+
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Technical Appendixes"
+msgstr ""
+
+#. type: Hash Value: Level1 Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Revision History"
+msgstr ""
+
+#. type: Hash Value: Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Fedora Installation Guide"
+msgstr ""
+
+#. type: Hash Value: bill-to address city
+#: basic.yaml:0
+#, no-wrap
+msgid "Royal Oak"
+msgstr ""
+
+#. type: Hash Value: invoice
+#: basic.yaml:0
+#, no-wrap
+msgid "34843"
+msgstr ""

--- a/t/fmt/yaml/keysandpaths1.trans
+++ b/t/fmt/yaml/keysandpaths1.trans
@@ -1,0 +1,101 @@
+---
+Dir: en-US
+Level1:
+  -
+    File: index
+    Name: 'BOOK INFORMATION'
+  -
+    File: Preface
+    Name: PREFACE
+  -
+    File: Introduction
+    Name: INTRODUCTION
+  -
+    File: Downloading_Fedora
+    Name: 'DOWNLOADING FEDORA'
+  -
+    Dir: INSTALL
+    Level2-a:
+      -
+        File: Preparing_for_Installation
+        Name: 'PREPARING FOR INSTALLATION'
+      -
+        File: Booting_the_Installation
+        Name: 'BOOTING THE INSTALLATION'
+      -
+        File: Installing_Using_Anaconda
+        Name: 'INSTALLING USING ANACONDA'
+      -
+        File: After_Installation
+        Name: 'AFTER THE INSTALLATION'
+      -
+        File: Troubleshooting
+        Name: TROUBLESHOOTING
+    Name: 'INSTALLING FEDORA'
+  -
+    Dir: ADVANCED
+    Level2-b:
+      -
+        File: Boot_Options
+        Name: 'BOOT OPTIONS'
+      -
+        File: Kickstart_Installations
+        Name: 'AUTOMATING THE INSTALLATION WITH KICKSTART'
+      -
+        File: Network_based_Installations
+        Name: 'SETTING UP AN INSTALLATION SERVER'
+      -
+        File: VNC_Installations
+        Name: 'INSTALLING USING VNC'
+      -
+        File: Upgrading_Your_Current_System
+        Name: 'UPGRAINDG YOUR CURRENT SYSTEM'
+    Name: 'ADVANCED INSTALLATION OPTIONS'
+  -
+    Dir: APPENDIXES
+    Level2-c:
+      -
+        File: Kickstart_Syntax_Reference
+        Name: 'KICKSTART SYNTAX REFERENCE'
+      -
+        File: Disk_Partitions
+        Name: 'AN INTRODUCTION TO DISK PARTITIONS'
+      -
+        File: Understanding_LVM
+        Name: 'UNDERSTANDING LVM'
+    Name: 'TECHNICAL APPENDIXES'
+  -
+    File: Revision_History
+    Name: 'REVISION HISTORY'
+Name: 'FEDORA INSTALLATION GUIDE'
+---
+bill-to:
+  address:
+    city: 'ROYAL OAK'
+    lines: "458 Walkman Dr.\nSuite #292\n"
+    postal: '48046'
+    state: MI
+  family: Dumars
+  given: Chris
+date: 2001-01-23
+invoice: '#34843#'
+product:
+  -
+    description: Basketball
+    price: '450.00'
+    quantity: '4'
+    sku: BL394D
+  -
+    description: 'Super Hoop'
+    price: '2392.00'
+    quantity: '1'
+    sku: BL4438H
+tax: '251.42'
+total: '4443.52'
+---
+- 'Mark McGwire'
+- 'Sammy Sosa'
+- 'Ken Griffey'
+---
+- 'Chicago Cubs'
+- 'St Louis Cardinals'

--- a/t/fmt/yaml/pathsoption1.po
+++ b/t/fmt/yaml/pathsoption1.po
@@ -1,0 +1,41 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2021-11-24 19:05+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Hash Value: Level1 Dir
+#: basic.yaml:0
+#, no-wrap
+msgid "install"
+msgstr "INSTALL"
+
+#. type: Hash Value: Level1 Dir
+#: basic.yaml:0
+#, no-wrap
+msgid "advanced"
+msgstr "ADVANCED"
+
+#. type: Hash Value: Level1 Dir
+#: basic.yaml:0
+#, no-wrap
+msgid "appendixes"
+msgstr "APPENDIXES"
+
+#. type: Hash Value: Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Fedora Installation Guide"
+msgstr "FEDORA INSTALLATION GUIDE"

--- a/t/fmt/yaml/pathsoption1.pot
+++ b/t/fmt/yaml/pathsoption1.pot
@@ -1,0 +1,41 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2021-11-24 19:05+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Hash Value: Level1 Dir
+#: basic.yaml:0
+#, no-wrap
+msgid "install"
+msgstr ""
+
+#. type: Hash Value: Level1 Dir
+#: basic.yaml:0
+#, no-wrap
+msgid "advanced"
+msgstr ""
+
+#. type: Hash Value: Level1 Dir
+#: basic.yaml:0
+#, no-wrap
+msgid "appendixes"
+msgstr ""
+
+#. type: Hash Value: Name
+#: basic.yaml:0
+#, no-wrap
+msgid "Fedora Installation Guide"
+msgstr ""

--- a/t/fmt/yaml/pathsoption1.trans
+++ b/t/fmt/yaml/pathsoption1.trans
@@ -1,0 +1,101 @@
+---
+Dir: en-US
+Level1:
+  -
+    File: index
+    Name: 'Book Information'
+  -
+    File: Preface
+    Name: Preface
+  -
+    File: Introduction
+    Name: Introduction
+  -
+    File: Downloading_Fedora
+    Name: 'Downloading Fedora'
+  -
+    Dir: INSTALL
+    Level2-a:
+      -
+        File: Preparing_for_Installation
+        Name: 'Preparing for Installation'
+      -
+        File: Booting_the_Installation
+        Name: 'Booting the Installation'
+      -
+        File: Installing_Using_Anaconda
+        Name: 'Installing Using Anaconda'
+      -
+        File: After_Installation
+        Name: 'After the Installation'
+      -
+        File: Troubleshooting
+        Name: Troubleshooting
+    Name: 'Installing Fedora'
+  -
+    Dir: ADVANCED
+    Level2-b:
+      -
+        File: Boot_Options
+        Name: 'Boot Options'
+      -
+        File: Kickstart_Installations
+        Name: 'Automating the Installation with Kickstart'
+      -
+        File: Network_based_Installations
+        Name: 'Setting Up an Installation Server'
+      -
+        File: VNC_Installations
+        Name: 'Installing Using VNC'
+      -
+        File: Upgrading_Your_Current_System
+        Name: 'Upgrading Your Current System'
+    Name: 'Advanced Installation Options'
+  -
+    Dir: APPENDIXES
+    Level2-c:
+      -
+        File: Kickstart_Syntax_Reference
+        Name: 'Kickstart Syntax Reference'
+      -
+        File: Disk_Partitions
+        Name: 'An Introduction to Disk Partitions'
+      -
+        File: Understanding_LVM
+        Name: 'Understanding LVM'
+    Name: 'Technical Appendixes'
+  -
+    File: Revision_History
+    Name: 'Revision History'
+Name: 'FEDORA INSTALLATION GUIDE'
+---
+bill-to:
+  address:
+    city: 'Royal Oak'
+    lines: "458 Walkman Dr.\nSuite #292\n"
+    postal: '48046'
+    state: MI
+  family: Dumars
+  given: Chris
+date: 2001-01-23
+invoice: '34843'
+product:
+  -
+    description: Basketball
+    price: '450.00'
+    quantity: '4'
+    sku: BL394D
+  -
+    description: 'Super Hoop'
+    price: '2392.00'
+    quantity: '1'
+    sku: BL4438H
+tax: '251.42'
+total: '4443.52'
+---
+- 'Mark McGwire'
+- 'Sammy Sosa'
+- 'Ken Griffey'
+---
+- 'Chicago Cubs'
+- 'St Louis Cardinals'


### PR DESCRIPTION
I have the need to filter which specific paths should be extracted from my Yaml files, not only on the key name.

To stay backwards compatible I didn't modify the handling of the `keys` parameter, but instead introduced a new one.

Example:

`/usr/src/po4a/po4a-gettextize -d -f yaml -m en/antora-playbook.yml -o paths="site title,site url,asciidoc attributes idseparator" -o keys="url" -o skip_array`

This would include **all** keys named `url` and additionally the specific elements addressed by the paths:

```yaml
site:
  # matched by paths
  title: User Manual
  # matched by both
  url: https://manual.example.com/en
  start_page: index.adoc
content:
  sources:
  # matched by keys
   - url: ..
      branches: HEAD
      start_path: en/
ui:
  bundle:
    # matched by keys
    url: https://files.example.com/ui-bundle-release.zip
    snapshot: true
asciidoc:
  attributes:
    idprefix: ""
    # matched by paths
    idseparator: "-"
    kroki-fetch-diagram: true
    kroki-plantuml-include: style.puml
  extensions:
    - asciidoctor-kroki
```
