### PR TITLE
Add new xhtml table test and stop claiming tables are not tested

### DIFF
--- a/lib/Locale/Po4a/Xhtml.pm
+++ b/lib/Locale/Po4a/Xhtml.pm
@@ -66,8 +66,7 @@ This module is fully functional, as it relies in the L<Locale::Po4a::Xml>
 module. This only defines the translatable tags and attributes.
 
 "It works for me", which means I use it successfully on my personal Web site.
-However, YMMV: please let me know if something doesn't work for you. In
-particular, tables are getting no testing whatsoever, as we don't use them.
+However, YMMV: please let me know if something doesn't work for you.
 
 =head1 SEE ALSO
 

--- a/t/fmt-xhtml.t
+++ b/t/fmt-xhtml.t
@@ -10,7 +10,7 @@ use Testhelper;
 
 my @tests;
 
-for my $t (qw(basic includessi closing-tag)) {
+for my $t (qw(basic includessi closing-tag table)) {
     push @tests, { 'format' => 'xhtml', 'input' => "fmt/xhtml/$t.html" };
 }
 

--- a/t/fmt/xhtml/table.html
+++ b/t/fmt/xhtml/table.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html>
+  <head>
+    <title>Simple test table</title>
+  </head>
+
+  <body>
+    <table id="ref1">
+      <caption>The table caption</caption>
+      <colgroup>
+	<col id="group"/> <col id="code"/> <col id="params"/> <col id="description"/>
+      </colgroup>
+      <tbody>
+	<tr id="titlerow"> <th>Code </th><th>Parameters </th><th>Description </th></tr>
+	<tr><th>Group</th><td colspan="2">Group note</td></tr>
+	<tr><td>Term</td><td/><td>Description</td></tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/t/fmt/xhtml/table.norm
+++ b/t/fmt/xhtml/table.norm
@@ -1,0 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html>
+  <head>
+    <title>Simple test table</title>
+  </head>
+
+  <body>
+    <table id="ref1">
+      <caption>The table caption</caption>
+      <colgroup>
+	<col id="group"/> <col id="code"/> <col id="params"/> <col id="description"/>
+      </colgroup>
+      <tbody>
+	<tr id="titlerow"> <th>Code </th><th>Parameters </th><th>Description </th></tr>
+	<tr><th>Group</th><td colspan="2">Group note</td></tr>
+	<tr><td>Term</td><td/><td>Description</td></tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/t/fmt/xhtml/table.po
+++ b/t/fmt/xhtml/table.po
@@ -1,0 +1,57 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2022-07-09 09:42+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Content of: <html><head><title>
+#: table.html:5
+msgid "Simple test table"
+msgstr "SIMPLE TEST TABLE"
+
+#. type: Content of: <html><body><table><caption>
+#: table.html:10
+msgid "The table caption"
+msgstr "THE TABLE CAPTION"
+
+#. type: Content of: <html><body><table><tbody><tr><th>
+#: table.html:15
+msgid "Code"
+msgstr "CODE"
+
+#. type: Content of: <html><body><table><tbody><tr><th>
+#: table.html:15
+msgid "Parameters"
+msgstr "PARAMETERS"
+
+#. type: Content of: <html><body><table><tbody><tr><td>
+#: table.html:15 table.html:17
+msgid "Description"
+msgstr "DESCRIPTION"
+
+#. type: Content of: <html><body><table><tbody><tr><th>
+#: table.html:16
+msgid "Group"
+msgstr "GROUP"
+
+#. type: Content of: <html><body><table><tbody><tr><td>
+#: table.html:16
+msgid "Group note"
+msgstr "GROUP NOTE"
+
+#. type: Content of: <html><body><table><tbody><tr><td>
+#: table.html:17
+msgid "Term"
+msgstr "TERM"

--- a/t/fmt/xhtml/table.pot
+++ b/t/fmt/xhtml/table.pot
@@ -1,0 +1,57 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2022-07-09 09:45+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Content of: <html><head><title>
+#: table.html:5
+msgid "Simple test table"
+msgstr ""
+
+#. type: Content of: <html><body><table><caption>
+#: table.html:10
+msgid "The table caption"
+msgstr ""
+
+#. type: Content of: <html><body><table><tbody><tr><th>
+#: table.html:15
+msgid "Code"
+msgstr ""
+
+#. type: Content of: <html><body><table><tbody><tr><th>
+#: table.html:15
+msgid "Parameters"
+msgstr ""
+
+#. type: Content of: <html><body><table><tbody><tr><td>
+#: table.html:15 table.html:17
+msgid "Description"
+msgstr ""
+
+#. type: Content of: <html><body><table><tbody><tr><th>
+#: table.html:16
+msgid "Group"
+msgstr ""
+
+#. type: Content of: <html><body><table><tbody><tr><td>
+#: table.html:16
+msgid "Group note"
+msgstr ""
+
+#. type: Content of: <html><body><table><tbody><tr><td>
+#: table.html:17
+msgid "Term"
+msgstr ""

--- a/t/fmt/xhtml/table.trans
+++ b/t/fmt/xhtml/table.trans
@@ -1,0 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html>
+  <head>
+    <title>SIMPLE TEST TABLE</title>
+  </head>
+
+  <body>
+    <table id="ref1">
+      <caption>THE TABLE CAPTION</caption>
+      <colgroup>
+	<col id="group"/> <col id="code"/> <col id="params"/> <col id="description"/>
+      </colgroup>
+      <tbody>
+	<tr id="titlerow"> <th>CODE </th><th>PARAMETERS </th><th>DESCRIPTION </th></tr>
+	<tr><th>GROUP</th><td colspan="2">GROUP NOTE</td></tr>
+	<tr><td>TERM</td><td/><td>DESCRIPTION</td></tr>
+      </tbody>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
The Xhtml documentation indicate that table support is not present
as it is not tested.  Tables seem to work, so lets add a test
and remove the documentation comment.