### PR TITLE
Avoid embedding the build date in compressed manpages

### DIFF
--- a/Po4aBuilder.pm
+++ b/Po4aBuilder.pm
@@ -234,7 +234,7 @@ sub ACTION_man {
         }
         $parser->parse_from_file ($file, $out);
 
-        system("gzip -9 -f $out") and die;
+        system("gzip -9 -n -f $out") and die;
         unlink "$file" || die;
     }
 
@@ -253,7 +253,7 @@ sub ACTION_man {
             print "Convert $outdir/$outfile.$section (online docbook.xsl file). ";
             system("xsltproc -o $outdir/$outfile.$section --nonet http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl $file") and die;
             }
-                system ("gzip -9 -f $outdir/$outfile.$section") and die;
+                system ("gzip -9 -n -f $outdir/$outfile.$section") and die;
             }
             unlink "$file" || die;
         }


### PR DESCRIPTION
Since the manpages are generated at build time, and gzip by
default includes the file timestamp in the compressed file,
this 'leaks' the build time into the resulting artifact.

There are many advantages to avoiding 'leaking' the build time
into the artifact: it can make detecting compromised CI servers
easier through https://reproducible-builds.org/ , can make
content-addressed storage more effective and improve cache hits
when rebuilding.