### PR TITLE
do not quote booleans in YAML

### DIFF
--- a/lib/Locale/Po4a/TransTractor.pm
+++ b/lib/Locale/Po4a/TransTractor.pm
@@ -1314,6 +1314,8 @@ sub handle_yaml {
                         $self->pushline("$header $el\n");
                     } elsif ( $el =~ /^\[.*\]$/ ) {    # Do not quote the lists either
                         $self->pushline("$header $el\n");
+                    } elsif ( $el =~ "false" or $el =~ "true" ) {   # Do not quote booleans either
+                        $self->pushline("$header $el\n");
                     } else {
                         $self->pushline( $header . ' ' . YAML::Tiny::_dump_scalar( "dummy", $el ) . "\n" );
                     }


### PR DESCRIPTION
Update to TransTractor.pm in order to avoid quotes being added around boolean values (true/false) in YAML and MarkDown front matter. If quotes are added the values are treated as strings rather than as booleans.