### PR TITLE
TeX.pm: allow \input command surrounded by curly braces

### DIFF
--- a/lib/Locale/Po4a/TeX.pm
+++ b/lib/Locale/Po4a/TeX.pm
@@ -969,7 +969,7 @@ sub read_file {
         while (
             $textline =~ /^((?:[^%]|(?<!\\)(?:\\\\)*\\%)*)
                               \\(include|input)
-                              \{([^\{]*)\}(.*)$/x
+                              \{([^\{\}]*)\}(.*)$/x
           )
         {
             my ( $begin, $newfilename, $end ) = ( $1, $3, $4 );


### PR DESCRIPTION
Previously, the closing brace `}` would be matched as part of the filename, which was then not found.

This allows the use of `\input` commands as macro parameters, for instance with the `\subcaptionbox` command:
```tex
\subcaptionbox{Legend}[2cm]{\input{sometikzplot.tex}}
```
Fixes #405 