### PR TITLE
TeX.pm: allow verbatim environment declaration without trailing space

### DIFF
--- a/lib/Locale/Po4a/TeX.pm
+++ b/lib/Locale/Po4a/TeX.pm
@@ -1122,7 +1122,7 @@ sub parse_definition_line {
         my $env = $1;    # This is not necessarily an environment.
                          # It can also be something like 'title[#1]'.
         $env_separators{$env} = $2;
-    } elsif ( $line =~ /^verbatim\s+environment\s+(\w+)\s+$/ ) {
+    } elsif ( $line =~ /^verbatim\s+environment\s+(\w+)\s*$/ ) {
         register_verbatim_environment($1);
     }
 }


### PR DESCRIPTION
Previously, a trailing space was matched by \s+, but this is counter-intuitive, and couldn't make it work before digging in the code.

Match the behavior of non-verbatim environment by making it \s* (allowing, but not requiring trailing spaces).