### PR TITLE
markdown: support link reference

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,9 @@ Tex:
  * Allow verbatim environment declaration without trailing space
    (GitHub's #407). Thanks Mayeul Cantan for the report & the fix.
 
+Markdown:
+ * Treat link reference definitions as no-wrap (GitHub's #422) [gemmaro].
+
 Translations:
  * Updated: French, thanks Jérémie Tarot.
  * Updated: German, thanks Helge Kreutzmann.

--- a/lib/Locale/Po4a/Text.pm
+++ b/lib/Locale/Po4a/Text.pm
@@ -736,6 +736,24 @@ sub parse_markdown {
         $self->pushline( $line . "\n" );
         $paragraph        = "";
         $end_of_paragraph = 1;
+    } elsif ( $line =~ /^([ ]{0,3})(\[[^\]]+\]:[ \t]?.+)$/ ) {
+        my $indentation   = $1;
+        my $linkreference = $2;
+
+        # Link reference
+        # TODO: support multiline link reference definition
+        # TODO: treat link title properly
+        # https://spec.commonmark.org/0.30/#link-reference-definitions
+        do_paragraph( $self, $paragraph, $wrapped_mode );
+        $wrapped_mode = 0;
+        $paragraph    = "";
+        my $t = $self->translate(
+            $linkreference, $self->{ref}, "Link reference",
+            "wrap"  => 0,
+            "flags" => "link-reference"
+        );
+        $self->pushline( $indentation . $t . "\n" );
+        $wrapped_mode = $defaultwrap;
     } elsif ( $line =~ /^([ ]{0,3})(([~`])\3{2,})(\s*)([^`]*)\s*$/ ) {
         my $fence_space_before  = $1;
         my $fence               = $2;

--- a/t/fmt/txt-markdown/Basic.md
+++ b/t/fmt/txt-markdown/Basic.md
@@ -18,3 +18,7 @@ The second paragraph.
 ## Subtitle
 
 And more text in a paragraph.
+
+This is a [link][] with long URL.
+
+[link]: https://example.com/sooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo/long

--- a/t/fmt/txt-markdown/Basic.norm
+++ b/t/fmt/txt-markdown/Basic.norm
@@ -19,3 +19,7 @@ The second paragraph.
 ## Subtitle
 
 And more text in a paragraph.
+
+This is a [link][] with long URL.
+
+[link]: https://example.com/sooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo/long

--- a/t/fmt/txt-markdown/Basic.po
+++ b/t/fmt/txt-markdown/Basic.po
@@ -7,7 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2023-06-01 01:27+0900\n"
+"PO-Revision-Date: 2023-06-01 01:32+0900\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@LI.ORG>\n"
 "Language: \n"
@@ -80,6 +81,17 @@ msgid "Subtitle"
 msgstr "SUBTITLE"
 
 #. type: Plain text
-#: Basic.md:20
+#: Basic.md:21
 msgid "And more text in a paragraph."
 msgstr "AND MORE TEXT IN A PARAGRAPH."
+
+#. type: Plain text
+#: Basic.md:23
+msgid "This is a [link][] with long URL."
+msgstr "THIS IS A [LINK][] WITH LONG URL."
+
+#. type: Link reference
+#: Basic.md:24
+#, no-wrap
+msgid "[link]: https://example.com/sooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo/long"
+msgstr "[LINK]: https://example.com/sooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo/long"

--- a/t/fmt/txt-markdown/Basic.pot
+++ b/t/fmt/txt-markdown/Basic.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-04-28 18:42+0200\n"
+"POT-Creation-Date: 2023-06-01 01:43+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -84,7 +84,21 @@ msgid "Subtitle"
 msgstr ""
 
 #. type: Plain text
-#: Basic.md:20
+#: Basic.md:21
 #, markdown-text
 msgid "And more text in a paragraph."
+msgstr ""
+
+#. type: Plain text
+#: Basic.md:23
+#, markdown-text
+msgid "This is a [link][] with long URL."
+msgstr ""
+
+#. type: Link reference
+#: Basic.md:24
+#, no-wrap
+msgid ""
+"[link]: "
+"https://example.com/sooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo/long"
 msgstr ""

--- a/t/fmt/txt-markdown/Basic.trans
+++ b/t/fmt/txt-markdown/Basic.trans
@@ -19,3 +19,7 @@ THE SECOND PARAGRAPH.
 ## SUBTITLE
 
 AND MORE TEXT IN A PARAGRAPH.
+
+THIS IS A [LINK][] WITH LONG URL.
+
+[LINK]: https://example.com/sooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo/long


### PR DESCRIPTION
This pull request marks link reference definitions in the markdown document as no-wrap, which avoids unintentional line breaks at the colon in the long link reference definition line.

Here are some limitations below, but I suspect it works in most cases:

* Multiline link reference definition is not supported ([Example 193](https://spec.commonmark.org/0.30/#example-193))
* It misinterprets a link reference definition if its link text is invalid ([Example 197](https://spec.commonmark.org/0.30/#example-197))
* Link reference definition may interrupt normal paragraph ([Example 213](https://spec.commonmark.org/0.30/#example-213))