### PR TITLE
New module for Org format

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,9 @@ __   __/ _ \|___  | || |
 General:
  * Fix a failure with Perl 5.40.
 
+Org:
+ * New module (GitHub's #485) [gemmaro].
+
 Translations:
  * Updated: Chinese (Traditional), thanks Ricky From Hong Kong.
  * Updated: Dutch, thanks Frans Spiesschaert.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ module for the following formats:
   - latex: LaTeX format.
   - bibtex: bibtex format.
   - man: Good old manual page format (either roff or mdoc).
+  - org: document format for the Org mode.
   - markdown: MD documents (using the txt module).
   - pod: Perl Online Documentation format.
   - rubydoc: RubyDoc (RD) documents.

--- a/doc/po4a.7.pod
+++ b/doc/po4a.7.pod
@@ -217,6 +217,12 @@ The native plain text format of the Gemini protocol.  The extension
 its infancy.  If you find anything, please file a bug or feature
 request.
 
+=item org (very highly experimental parser)
+
+The document format used by the Org mode.  Support for this module in
+po4a is still in its infancy.  If you find anything, please file a bug
+or feature request.
+
 =item Others supported formats
 
 Po4a can also handle some more rare or specialized formats, such as the
@@ -860,9 +866,10 @@ L<Locale::Po4a::RubyDoc(3pm)>, L<Locale::Po4a::Texinfo(3pm)>,
 L<Locale::Po4a::Text(3pm)>, L<Locale::Po4a::Xhtml(3pm)>,
 L<Locale::Po4a::Yaml(3pm)>, L<Locale::Po4a::BibTeX(3pm)>,
 L<Locale::Po4a::Docbook(3pm)>, L<Locale::Po4a::Halibut(3pm)>,
-L<Locale::Po4a::LaTeX(3pm)>, L<Locale::Po4a::Pod(3pm)>,
-L<Locale::Po4a::Sgml(3pm)>, L<Locale::Po4a::TeX(3pm)>,
-L<Locale::Po4a::Wml(3pm)>, L<Locale::Po4a::Xml(3pm)>.
+L<Locale::Po4a::LaTeX(3pm)>, L<Locale::Po4a::Org(3pm)>,
+L<Locale::Po4a::Pod(3pm)>, L<Locale::Po4a::Sgml(3pm)>,
+L<Locale::Po4a::TeX(3pm)>, L<Locale::Po4a::Wml(3pm)>,
+L<Locale::Po4a::Xml(3pm)>.
 
 =item
 

--- a/lib/Locale/Po4a/Chooser.pm
+++ b/lib/Locale/Po4a/Chooser.pm
@@ -78,6 +78,8 @@ sub list {
           . "\n  - "
           . gettext("man: Good old manual page format.")
           . "\n  - "
+          . gettext("org: document format for Org mode.")
+          . "\n  - "
           . gettext("pod: Perl Online Documentation format.")
           . "\n  - "
           . gettext("rubydoc: Ruby Documentation (RD) format.")
@@ -149,6 +151,7 @@ L<Locale::Po4a::Ini(3pm)>,
 L<Locale::Po4a::KernelHelp(3pm)>,
 L<Locale::Po4a::LaTeX(3pm)>,
 L<Locale::Po4a::Man(3pm)>,
+L<Locale::Po4a::Org(3pm)>,
 L<Locale::Po4a::Pod(3pm)>,
 L<Locale::Po4a::RubyDoc(3pm)>,
 L<Locale::Po4a::Sgml(3pm)>,

--- a/lib/Locale/Po4a/Org.pm
+++ b/lib/Locale/Po4a/Org.pm
@@ -1,0 +1,467 @@
+#!/usr/bin/env perl -w
+
+# Po4a::Org.pm
+#
+# extract and translate translatable strings from a Org documents
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+########################################################################
+
+package Locale::Po4a::Org;
+
+use 5.006;
+use strict;
+use warnings;
+
+use parent qw(Locale::Po4a::TransTractor);
+
+sub initialize {
+    my ( $self, %options ) = @_;
+
+    $self->{options}{skip_keywords}   = [];
+    $self->{options}{skip_properties} = [];
+    $self->{options}{skip_heading}    = 0;
+    $self->{options}{debug}           = 0;
+    $self->{options}{verbose}         = 0;
+
+    foreach my $opt ( keys %options ) {
+        exists $self->{options}{$opt}
+          or die wrap_mod( 'po4a::org', dgettext( 'po4a', 'Unknown option: %s' ), $opt );
+    }
+
+    $self->{options}{skip_heading} = $options{skip_heading};
+    $self->{options}{debug}        = $options{debug};
+    $self->{options}{verbose}      = $options{verbose};
+
+    foreach my $option_name ( 'skip_keywords', 'skip_properties' ) {
+        my $option = $options{$option_name} or next;
+        push @{ $self->{options}{$option_name} }, split / \s+ /xsm, $option;
+    }
+
+    return;
+}
+
+sub parse {
+    my $self = shift;
+
+    $self->{blocks}    = [];
+    $self->{paragraph} = undef;
+
+    my ( $line, $ref ) = $self->shiftline();
+
+    while ( defined $line ) {
+        chomp $line;
+
+             $self->parse_keyword( $line, $ref )
+          or $self->parse_properties( $line, $ref )
+          or $self->parse_small_literal_block( $line, $ref )
+          or $self->parse_heading( $line, $ref )
+          or $self->parse_block_begin( $line, $ref )
+          or $self->parse_block_end( $line, $ref )
+          or $self->parse_plain_list( $line, $ref )
+          or $self->parse_table( $line, $ref )
+          or $self->parse_blank_line( $line, $ref )
+          or $self->parse_comment( $line, $ref )
+          or $self->parse_paragraph( $line, $ref );
+
+        ( $line, $ref ) = $self->shiftline();
+    }
+
+    $self->handle_paragraph_if_any($ref);
+
+    return;
+}
+
+sub parse_keyword {
+    my ( $self, $line, $ref ) = @_;
+
+    $line =~ m{ \A ( [#] [+] ( [^:]+ ) : [ ]+ ) (.+) }xsm or return;
+    my $prefix  = $1;
+    my $name    = $2;
+    my $content = $3;
+
+    for ( @{ $self->{options}{skip_keywords} } ) {
+        if ( $_ eq $name ) {
+            $self->pushline("$line\n");
+            return 1;
+        }
+    }
+
+    $content = $self->translate( $content, $ref, "keyword $name" );
+    $self->pushline("$prefix$content\n");
+
+    return 1;
+}
+
+sub parse_properties {
+    my ( $self, $line, $ref ) = @_;
+
+    $line eq ':PROPERTIES:' or return;
+
+    $self->pushline("$line\n");
+    ( $line, $ref ) = $self->shiftline();
+
+    while ( defined $line ) {
+        chomp $line;
+
+        if ( $line eq ':END:' ) {
+            $self->pushline("$line\n");
+            return 1;
+        }
+
+        $line =~ m{ ( : ( [^:]+ ) : [ ]+ ) (.+) }xsm
+          or die "invalid property entry: $line\n";
+        my $pre     = $1;
+        my $key     = $2;
+        my $content = $3;
+
+        my $translatable = 1;
+        for ( @{ $self->{options}{skip_properties} } ) {
+            if ( $_ eq $key ) {
+                $translatable = 0;
+            }
+        }
+
+        $translatable and $content = $self->translate( $content, $ref, "property ($key)" );
+        $self->pushline("$pre$content\n");
+        ( $line, $ref ) = $self->shiftline();
+    }
+
+    return;
+}
+
+sub parse_small_literal_block {
+    my ( $self, $line, $ref ) = @_;
+
+    $line =~ m{ \A ( [ ]*:[ ] ) (.*) }xsm or return;
+    my $pre     = $1;
+    my $content = $2;
+
+    my $newref;
+    ( $line, $newref ) = $self->shiftline();
+
+    while ( defined $line ) {
+        chomp $line;
+
+        if ( $line =~ m{ \A (?: [ ]* : [ ] ) (.*) }xsm ) {
+            $content .= "\n$1";
+            ( $line, $newref ) = $self->shiftline();
+            next;
+        }
+
+        my $type = 'small literal example';
+        $self->annotate_blocks( \$type );
+        $content = $self->translate( $content, $ref, $type );
+        $content =~ s/ ^ /$pre/mgxs;
+        $self->pushline("$content\n");
+        $self->unshiftline( $line, $newref );
+
+        return 1;
+    }
+
+    return;
+}
+
+sub parse_heading {
+    my ( $self, $line, $ref ) = @_;
+
+    $line =~ m{ \A ( ( [*]+ ) [ ]+ ) (.+?) (?: \s+ ( : (?: [^:]+ : )+ ) )? \Z }xsm
+      or return;
+    my $pre     = $1;
+    my $level   = $2;
+    my $content = $3;
+    my $tags    = $4;
+
+    if ( $self->{options}{skip_heading} ) {
+        $self->pushline("$line\n");
+    } else {
+        my $result = $pre . $self->translate( $content, $ref, "heading $level" );
+        $tags and $result .= " $tags";
+        $self->pushline("$result\n");
+    }
+
+    return 1;
+}
+
+sub parse_block_begin {
+    my ( $self, $line, $ref ) = @_;
+
+    $line =~ m{ \A [ ]* [#] [+] begin_([[:lower:]]+) ([ ]*) (.*) }ixsm
+      or return;
+    my $name       = $1;
+    my $postspaces = $2;
+    my $args       = $3;
+
+    push @{ $self->{blocks} }, $name;
+    $self->pushline("$line\n");
+
+    return 1;
+}
+
+sub parse_block_end {
+    my ( $self, $line, $ref ) = @_;
+
+    $line =~ m{ \A [ ]* [#] [+] end_(?:[[:lower:]]+) \Z }ixsm or return;
+
+    $self->handle_paragraph_if_any($ref);
+    pop @{ $self->{blocks} };
+    $self->pushline("$line\n");
+
+    return 1;
+}
+
+sub parse_plain_list {
+    my ( $self, $line, $ref ) = @_;
+
+    $line =~ m{ \A ( ( ([-+*]) | \d+[.)] ) [ ]+ ) (.*) }xsm or return;
+    my $prefix   = $1;
+    my $type     = $2;
+    my $itemized = $3;
+    my @content  = $4;
+
+    my $margin = q{ } x length $prefix;
+
+    if ( $content[0] =~ m{ (.*?) ([ ]::) \Z }xsm ) {
+        my $term   = $1;
+        my $suffix = $2;
+
+        my $content = $self->translate( $term, $ref, "description list term $type" );
+        $self->pushline("$prefix$content$suffix\n");
+        pop @content;
+
+        if (@content) {
+            my $ref = $self->parse_plain_list_following_paragraph( \@content, $margin );
+            $content = $self->translate( join( "\n", @content ), $ref, "description list $type" );
+            $content =~ s/ ^ /$margin/mgxs;
+            $self->pushline("$content\n");
+        }
+    } else {
+        my $ref = $self->parse_plain_list_following_paragraph( \@content, $margin );
+        my $content = $self->translate( join( "\n", @content ), $ref, "plain list $type" );
+        $content =~ s/ ^ /$margin/mgxs;
+        $content =~ s/ \A \Q$margin\E //xsm;
+        $self->pushline("$prefix$content\n");
+    }
+
+    return 1;
+}
+
+sub parse_plain_list_following_paragraph {
+    my ( $self, $content, $margin ) = @_;
+
+    my ( $line, $ref ) = $self->shiftline();
+    while ( defined $line ) {
+        chomp $line;
+
+        if ( $line =~ m/ \A \Q$margin\E (.*) /xsm ) {
+            push @{$content}, $1;
+
+            ( $line, $ref ) = $self->shiftline();
+        } else {
+            $self->unshiftline( $line, $ref );
+            last;
+        }
+    }
+
+    return $ref;
+}
+
+sub parse_table {
+    my ( $self, $line, $ref ) = @_;
+
+    $line =~ m{ \A ( [ ]* [|] [ ]* ) (.*) }xsm or return;
+    my $prefix = $1;
+    my $cells  = $2;
+
+    if ( $cells =~ / \A [-+|]* \Z /xsm ) {
+        $self->pushline("$line\n");
+    } else {
+        my @cells = split / [ ]* [|] [ ]* /xsm, $cells;
+        my $content = join( ' | ', map { $self->translate( $cells[$_], $ref, "cell column $_" ) } ( 0 .. $#cells ) );
+        $self->pushline("$prefix$content |\n");
+    }
+
+    return 1;
+}
+
+sub parse_blank_line {
+    my ( $self, $line, $ref ) = @_;
+
+    $line =~ / \A \s* \Z /xsm or return;
+    $self->handle_paragraph_if_any($ref);
+    $self->pushline("\n");
+
+    return 1;
+}
+
+sub parse_comment {
+    my ( $self, $line ) = @_;
+
+    $line =~ / \A [ ]* [#] .* /xsm or return;
+    $self->pushline("$line\n");
+
+    return 1;
+}
+
+sub parse_paragraph {
+    my ( $self, $line, $ref ) = @_;
+
+    if ( $self->{paragraph} ) {
+
+        # continuation
+
+        if ( $line =~ s/ \A \Q$self->{paragraph_margin}\E //xms ) {
+            $self->{paragraph} .= "\n$line";
+        } else {
+            $line =~ m{ \A ([ ]*) (.*) }xsm or return;
+            my $margin  = $1;
+            my $content = $2;
+
+            $self->{paragraph} =~ s/ ^ /$self->{paragraph_margin}/mgxs;
+            $self->{paragraph} =~ s/ ^ \Q$margin\E //mgxs;
+            $self->{paragraph} .= "\n$content";
+            $self->{paragraph_margin} = $margin;
+        }
+    } else {
+
+        # start
+
+        $line =~ m{ \A ([ ]*) (.+) }xsm or return;
+        $self->{paragraph_margin} = $1;
+        $self->{paragraph}        = $2;
+    }
+
+    return 1;
+}
+
+sub handle_paragraph_if_any {
+    my ( $self, $ref ) = @_;
+
+    $self->{paragraph} or return;
+    my $type = 'paragraph';
+    $self->annotate_blocks( \$type );
+
+    my $wrap         = 1;
+    my @nowrap_names = qw(src example);
+  WRAP:
+    for my $block ( @{ $self->{blocks} } ) {
+        for my $nowrap_name (@nowrap_names) {
+            if ( lc($block) eq $nowrap_name ) {
+                undef $wrap;
+                last WRAP;
+            }
+        }
+    }
+
+    my $content = $self->translate( $self->{paragraph}, $ref, $type, wrap => $wrap );
+    $content =~ s/ ^ /$self->{paragraph_margin}/mgxs;
+    $self->pushline("$content\n");
+
+    undef $self->{paragraph};
+    undef $self->{paragraph_margin};
+
+    return;
+}
+
+sub annotate_blocks {
+    my ( $self, $type ) = @_;
+
+    if ( @{ $self->{blocks} } ) {
+        my $blocks = join q{/}, @{ $self->{blocks} };
+        ${$type} .= " in $blocks";
+    }
+
+    return;
+}
+
+1;
+
+__END__
+
+=encoding UTF-8
+
+=head1 NAME
+
+Locale::Po4a::Org - convert Org documents from/to PO files.
+
+=head1 SYNOPSIS
+
+ [type:org] /path/to/master.org				\
+	    $lang:/path/to/translation.$lang.org	\
+	    opt:"					\
+		--option skip_keywords='		\
+		    include				\
+		    export_file_name			\
+		    link'				\
+		--option skip_properties='		\
+		    copying				\
+		    NOBLOCKING				\
+		    ORDERED'"
+
+=head1 DESCRIPTION
+
+The po4a (PO for anything) project goal is to ease translations (and
+more interestingly, the maintenance of translations) using gettext
+tools on areas where they were not expected like documentation.
+
+C<Locale::Po4a::Org> is a module to help the translation of
+documentation in the Org format, used by the L<Org
+Mode|https://orgmode.org/>.
+
+=head1 CONFIGURATION
+
+=over
+
+=item B<skip_keywords>
+
+Space-separated list of keywords which won't be translated.
+
+=item B<skip_properties>
+
+Space-separated list of properties which won't be translated.
+
+=item B<skip_heading>
+
+If this is a true value, skip translating headings.  When your
+translation is converted to Texinfo format, the translation of
+headings can cause node names to become bizarre.  This option prevents
+that.
+
+=back
+
+=head1 STATUS OF THIS MODULE
+
+This module is in an early stage of development.  It is tested
+successfully on simple Org files, such as the L<Org Mode Compact
+Guide|https://orgmode.org/guide/>.  However it does not support the
+full L<Org syntax|https://orgmode.org/worg/org-syntax.html>; footnotes
+and nested plain lists cannot currently be parsed, for example.
+
+=head1 SEE ALSO
+
+L<Locale::Po4a::TransTractor(3pm)>, L<po4a(7)|po4a.7>
+
+=head1 AUTHORS
+
+ gemmaro <gemmaro.dev@gmail.com>
+
+=head1 COPYRIGHT AND LICENSE
+
+ Copyright © 2024 gemmaro.
+
+This program is free software; you may redistribute it and/or modify it
+under the terms of GPL v2.0 or later (see the F<COPYING> file).

--- a/po/pod.cfg
+++ b/po/pod.cfg
@@ -49,6 +49,8 @@
             add_$lang:?doc/addendum.$lang
 [type: pod] lib/Locale/Po4a/Man.pm          $lang:blib/man/$lang/man3/Locale::Po4a::Man.3pm.pod \
             add_$lang:?doc/addendum.$lang
+[type: pod] lib/Locale/Po4a/Org.pm          $lang:blib/man/$lang/man3/Locale::Po4a::Org.3pm.pod \
+            add_$lang:?doc/addendum.$lang
 [type: pod] lib/Locale/Po4a/Po.pm           $lang:blib/man/$lang/man3/Locale::Po4a::Po.3pm.pod \
             add_$lang:?doc/addendum.$lang
 [type: pod] lib/Locale/Po4a/Pod.pm          $lang:blib/man/$lang/man3/Locale::Po4a::Pod.3pm.pod \

--- a/t/fmt-org.t
+++ b/t/fmt-org.t
@@ -1,0 +1,20 @@
+# Org module tester.
+
+#########################
+
+use strict;
+use warnings;
+
+use lib q(t);
+use Testhelper;
+
+my @tests;
+
+push @tests,
+  {
+    'format' => 'org',
+    'input'  => 'fmt/org/basic.org',
+  };
+
+run_all_tests(@tests);
+0;

--- a/t/fmt/org/basic.norm
+++ b/t/fmt/org/basic.norm
@@ -1,0 +1,29 @@
+#+FILETAGS: sample
+
+* This is a heading
+
+** This is also a heading
+:PROPERTIES:
+:CUSTOM_ID: custom-id
+:END:
+
+: This is a small literal block.
+
+#+begin_example
+  po4a /path/to/config
+#+end_example
+
+- First item
+- Second item
+  - Sub item
+- Third item
+
+| IATA | City |
+|------+------------|
+| CDG | Paris |
+| LIL | Lille |
+| SXB | Strasbourg |
+
+# This is a comment.
+
+This is a paragraph.  And a second sentence.

--- a/t/fmt/org/basic.org
+++ b/t/fmt/org/basic.org
@@ -1,0 +1,30 @@
+#+FILETAGS: sample
+
+* This is a heading
+
+** This is also a heading
+:PROPERTIES:
+:CUSTOM_ID: custom-id
+:END:
+
+: This is a small literal block.
+
+#+begin_example
+  po4a /path/to/config
+#+end_example
+
+- First item
+- Second item
+  - Sub item
+- Third item
+
+| IATA | City       |
+|------+------------|
+| CDG  | Paris      |
+| LIL  | Lille      |
+| SXB  | Strasbourg |
+
+# This is a comment.
+
+This is a paragraph.
+And a second sentence.

--- a/t/fmt/org/basic.po
+++ b/t/fmt/org/basic.po
@@ -1,0 +1,126 @@
+# Language basic translations for po package
+# Copyright (C) 2024 Free Software Foundation, Inc.
+# This file is distributed under the same license as the po package.
+# Automatically generated, 2024.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: po 4a\n"
+"POT-Creation-Date: 2024-08-31 09:29+0900\n"
+"PO-Revision-Date: 2024-02-27 16:45+0900\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: basic\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: keyword FILETAGS
+#: basic.org:1
+#, no-wrap
+msgid "sample"
+msgstr "SAMPLE"
+
+#. type: heading *
+#: basic.org:3
+#, no-wrap
+msgid "This is a heading"
+msgstr "THIS IS A HEADING"
+
+#. type: heading **
+#: basic.org:5
+#, no-wrap
+msgid "This is also a heading"
+msgstr "THIS IS ALSO A HEADING"
+
+#. type: property (CUSTOM_ID)
+#: basic.org:7
+#, no-wrap
+msgid "custom-id"
+msgstr "CUSTOM-ID"
+
+#. type: small literal example
+#: basic.org:10
+#, no-wrap
+msgid "This is a small literal block."
+msgstr "THIS IS A SMALL LITERAL BLOCK."
+
+#. type: paragraph in example
+#: basic.org:14
+#, no-wrap
+msgid "po4a /path/to/config"
+msgstr "PO4A /PATH/TO/CONFIG"
+
+#. type: plain list -
+#: basic.org:17
+#, no-wrap
+msgid "First item"
+msgstr "FIRST ITEM"
+
+#. type: plain list -
+#: basic.org:19
+#, no-wrap
+msgid ""
+"Second item\n"
+"- Sub item"
+msgstr ""
+"SECOND ITEM\n"
+"- SUB ITEM"
+
+#. type: plain list -
+#: basic.org:20
+#, no-wrap
+msgid "Third item"
+msgstr "THIRD ITEM"
+
+#. type: cell column 0
+#: basic.org:21
+#, no-wrap
+msgid "IATA"
+msgstr "IATA"
+
+#. type: cell column 1
+#: basic.org:21
+#, no-wrap
+msgid "City"
+msgstr "CITY"
+
+#. type: cell column 0
+#: basic.org:23
+#, no-wrap
+msgid "CDG"
+msgstr "CDG"
+
+#. type: cell column 1
+#: basic.org:23
+#, no-wrap
+msgid "Paris"
+msgstr "PARIS"
+
+#. type: cell column 0
+#: basic.org:24
+#, no-wrap
+msgid "LIL"
+msgstr "LIL"
+
+#. type: cell column 1
+#: basic.org:24
+#, no-wrap
+msgid "Lille"
+msgstr "LILLE"
+
+#. type: cell column 0
+#: basic.org:25
+#, no-wrap
+msgid "SXB"
+msgstr "SXB"
+
+#. type: cell column 1
+#: basic.org:25
+#, no-wrap
+msgid "Strasbourg"
+msgstr "STRASBOURG"
+
+#. type: paragraph
+msgid "This is a paragraph.  And a second sentence."
+msgstr "THIS IS A PARAGRAPH.  AND A SECOND SENTENCE."

--- a/t/fmt/org/basic.pot
+++ b/t/fmt/org/basic.pot
@@ -1,0 +1,125 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2024-08-31 09:28+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: keyword FILETAGS
+#: basic.org:1
+#, no-wrap
+msgid "sample"
+msgstr ""
+
+#. type: heading *
+#: basic.org:3
+#, no-wrap
+msgid "This is a heading"
+msgstr ""
+
+#. type: heading **
+#: basic.org:5
+#, no-wrap
+msgid "This is also a heading"
+msgstr ""
+
+#. type: property (CUSTOM_ID)
+#: basic.org:7
+#, no-wrap
+msgid "custom-id"
+msgstr ""
+
+#. type: small literal example
+#: basic.org:10
+#, no-wrap
+msgid "This is a small literal block."
+msgstr ""
+
+#. type: paragraph in example
+#: basic.org:14
+#, no-wrap
+msgid "po4a /path/to/config"
+msgstr ""
+
+#. type: plain list -
+#: basic.org:17
+#, no-wrap
+msgid "First item"
+msgstr ""
+
+#. type: plain list -
+#: basic.org:19
+#, no-wrap
+msgid ""
+"Second item\n"
+"- Sub item"
+msgstr ""
+
+#. type: plain list -
+#: basic.org:20
+#, no-wrap
+msgid "Third item"
+msgstr ""
+
+#. type: cell column 0
+#: basic.org:21
+#, no-wrap
+msgid "IATA"
+msgstr ""
+
+#. type: cell column 1
+#: basic.org:21
+#, no-wrap
+msgid "City"
+msgstr ""
+
+#. type: cell column 0
+#: basic.org:23
+#, no-wrap
+msgid "CDG"
+msgstr ""
+
+#. type: cell column 1
+#: basic.org:23
+#, no-wrap
+msgid "Paris"
+msgstr ""
+
+#. type: cell column 0
+#: basic.org:24
+#, no-wrap
+msgid "LIL"
+msgstr ""
+
+#. type: cell column 1
+#: basic.org:24
+#, no-wrap
+msgid "Lille"
+msgstr ""
+
+#. type: cell column 0
+#: basic.org:25
+#, no-wrap
+msgid "SXB"
+msgstr ""
+
+#. type: cell column 1
+#: basic.org:25
+#, no-wrap
+msgid "Strasbourg"
+msgstr ""
+
+#. type: paragraph
+msgid "This is a paragraph.  And a second sentence."
+msgstr ""

--- a/t/fmt/org/basic.trans
+++ b/t/fmt/org/basic.trans
@@ -1,0 +1,29 @@
+#+FILETAGS: SAMPLE
+
+* THIS IS A HEADING
+
+** THIS IS ALSO A HEADING
+:PROPERTIES:
+:CUSTOM_ID: CUSTOM-ID
+:END:
+
+: THIS IS A SMALL LITERAL BLOCK.
+
+#+begin_example
+  PO4A /PATH/TO/CONFIG
+#+end_example
+
+- FIRST ITEM
+- SECOND ITEM
+  - SUB ITEM
+- THIRD ITEM
+
+| IATA | CITY |
+|------+------------|
+| CDG | PARIS |
+| LIL | LILLE |
+| SXB | STRASBOURG |
+
+# This is a comment.
+
+THIS IS A PARAGRAPH.  AND A SECOND SENTENCE.


### PR DESCRIPTION
Hello,

This is a new module for the Org format, which is typically used in [the Org mode][org].
I have used this module to translate some of their documents (such as the [Org Mode Compact Guide][guide]), and it seems to work.

~~This also adds some links to the Gemtext module (#466).~~ I'll make another pull request.

Thank you,
gemmaro.

- - -

TODO:

- [x] I have added List::Util to the dependencies, but considering whether it is really necessary.
      It is useful for manipulating lists, but as more dependencies are added, the packaging will need to be updated.
- [x] Fixes translate() and pushline() usage.
      There are places where $ref and $type are missed or extra passed.
- [x] Regular expressions improvements, e.g.  `\A` should be used instead of `^` in some places.
- [x] Conflict resolution.

These tasks are future work:

- Conform to [the Org Syntax](https://orgmode.org/worg/org-syntax.html)
- Improved parser when targeting the Org reference manual.

[org]: https://orgmode.org/
[guide]: https://orgmode.org/guide/