### PR TITLE
po4a-normalize: add an option to create capitalized version of documenе

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,78 +122,106 @@ In order to define a new test, you can use some convenience
 helpers. If you follow some conventions, you don't have to
 write much boilerplate code.
 
-Each test is defined using a perl hash with several keys.
-Every test needs to have the key "_doc_", which contains
-a short description of the test.
+Each test is defined using a perl hash with several keys.  Every test
+should have the key `doc`, which contains a short description of the
+test.
 
-If you need to test the output of a module, it should suffice
-to define a second key in the hash, named "_normalize_".
-This key points to a string which can be used for the
-script `po4a-normalize`. See for example the YAML tests
-for some easy test definitions.
+Currently the test suit supports 3 types of tests:
 
-The "_normalize_" tests expect to find at least four files
-in the corresponding test directory:
+ - *po4a.conf* - to test the __po4a__ utility
+ - *format* - to test the specific format modules
+ - *run* - old generic run-commands-tests that wasn't or couldn't be
+    converted to one of the above formats
 
-1. The master file used as input for po4a.
-2. The expected .pot file, using the same name as the master
-   file. The extension is changed to "_.pot_".
-3. The expected translated file, again using the same name
-   as the master file. The extension is changed to "_.out_".
-4. The expected messages on stderr, again using the same name
-   as the master file. The extension is changed to "_.err_".
-
-Here's an example. If you define the following hash:
-
-```
-push @tests,
-  {
-    'doc'       => "YAML UTF-8 test",
-    'normalize' => "-f yaml -M UTF-8 t-25-yaml/yamlutf8.yaml",
-  };
-```
-
-... you need to have at least the following four files:
-
-```
-t-25-yaml/yamlutf8.yaml
-t-25-yaml/yamlutf8.pot
-t-25-yaml/yamlutf8.out
-t-25-yaml/yamlutf8.err
-```
-
-You can also check that the translation works, using the file
-name of the master file, with the extension changed to
-"_.trans.po_". The actual language does not matter, the
-extension is always the same. Similarly to the above files,
-you also need to add the expected translated output and
-the expected messages from stderr:
-
-```
-t-25-yaml/yamlutf8.trans.po
-t-25-yaml/yamlutf8.trans.out
-t-25-yaml/yamlutf8.trans.err
-```
-
-If you need to have more control over your tests, you can
-use the "_run_" and "_test_" keys in the hash. The "_run_"
-key defines the commands to run; the "_test_" key has
-the commands to check the generated output.
-
-Last, not least, you can mark a test as TODO with the
-hash key "_todo_". Usually, it's best to write a short
-description or to add a link to the online bug report.
+Also, you can mark a test as TODO with the hash key "_todo_". Usually,
+it's best to write a short description or to add a link to the online
+bug report.
 
 Example:
 
 ```
 push @tests,
   {
-    'doc'       => 'WML normalisation test',
-    'normalize' => "-f wml t-22-wml/general.wml",
+    'format'    => "wml" 
+    'input'     => "fmt/wml/general.wml",
     'todo'      => "https://github.com/mquinson/po4a/issues/138",
   };
 ```
+### *po4a.conf* tests
+
+Thees tests are used to check how well po4a can handle different
+options in a `po4a.conf` see example tests and **Testhelper.pm** for
+more details.
+
+### *Format* tests
+
+If you need to test the output of a module, you should define at least
+two keys in the hash: `format` and `input`. The first one
+specifies the format which will be passed to option `-f` of utilities
+like *po4a-translate* or *po4a-normalize*. The second one specifies
+the input file to perform the tests on. It is not strictly necessary
+to specify the `doc` key, but it is encouraged if you have more than
+one test for a single `format`.
+
+See for example the manpage tests for some simple test definitions.
+
+The "*format*" tests expect to find the next five files:
+
+1. The master file (`input`) used as input for po4a.
+2. The expected normalized file, with the same basename and the
+   "*.norm*" extension. (May be overridden with `norm` key).
+3. The expected .pot file, again with the same basename as the master
+   file and the extension "_.pot_" (May be overridden with `potfile`
+   key).
+4. The expected .po file, using again the same basename and the
+   extension "_.po_" (May be overridden with `pofile` key ).
+5. The expected translated file, again with the same basename and the
+   "*.trans*" extension. (May be overridden with `trans` key).
+
+Here's an example. If you define the following hash:
+
+```
+push @tests,
+  {
+    'format' => 'man',
+    'input'  => 'fmt/man/null.man'
+  };
+```
+... you need to have the following five files:
+
+```
+fmt/man/null.man
+fmt/man/null.norm
+fmt/man/null.pot
+fmt/man/null.po
+fmt/man/null.trans
+```
+
+The actual language of PO-files does not generally matter, but all
+existing *format* tests use uppercase of the original strings for
+translations so it would be easier to all contributors.
+
+The master file you have to write yourself, the rest could be easily
+generated with *po4a-normalize*:
+
+```
+cd t/fmt/man/
+PERL5LIB=../../../lib/ perl ../../../po4a-normalize -f man null.man -l null.norm -p null.pot
+PERL5LIB=../../../lib/ perl ../../../po4a-normalize -C -f man null.man -l null.trans -p null.po
+```
+
+... but you should furiously check those, that they are actually what
+you expect.
+
+The *format* tests also have other options. For full list and
+description see comments in **Testhelper.pm**.
+
+### *Run* tests
+
+If you need to have more control over your tests, you can
+use the "_run_" and "_test_" keys in the hash. The "_run_"
+key defines the commands to run; the "_test_" key has
+the commands to check the generated output.
 
 # Submitting Your Patch
 

--- a/po/pod/ca.po
+++ b/po/pod/ca.po
@@ -2482,7 +2482,7 @@ msgstr "B<-b>, B<--blank>"
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 

--- a/po/pod/de.po
+++ b/po/pod/de.po
@@ -2892,7 +2892,7 @@ msgstr "B<-b>, B<--blank>"
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 "Erstellt ein leeres übersetztes Dokument. Das erstellte übersetzte Dookument "

--- a/po/pod/eo.po
+++ b/po/pod/eo.po
@@ -2219,7 +2219,7 @@ msgstr ""
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 

--- a/po/pod/es.po
+++ b/po/pod/es.po
@@ -2942,7 +2942,7 @@ msgstr "B<-b>, B<--blank>"
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 "Crea un documento traducido en blanco. El documento traducido generado se "

--- a/po/pod/fr.po
+++ b/po/pod/fr.po
@@ -2891,7 +2891,7 @@ msgstr "B<-b>, B<--blank>"
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 "Crée une traduction « blanche » du document. Le document traduit sera généré "

--- a/po/pod/hr.po
+++ b/po/pod/hr.po
@@ -2172,7 +2172,7 @@ msgstr ""
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 

--- a/po/pod/hu.po
+++ b/po/pod/hu.po
@@ -2202,7 +2202,7 @@ msgstr ""
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 

--- a/po/pod/it.po
+++ b/po/pod/it.po
@@ -2858,7 +2858,7 @@ msgstr "B<-b>, B<--blank>"
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 "Creare un documento tradotto vuoto.  Il documento tradotto generato verrà "

--- a/po/pod/ja.po
+++ b/po/pod/ja.po
@@ -2736,7 +2736,7 @@ msgstr "B<-b>, B<--blank>"
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 "空の翻訳済みドキュメントを作成します。生成した翻訳済みドキュメントは、すべて"

--- a/po/pod/nb.po
+++ b/po/pod/nb.po
@@ -2213,7 +2213,7 @@ msgstr ""
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 

--- a/po/pod/nl.po
+++ b/po/pod/nl.po
@@ -2966,7 +2966,7 @@ msgstr "B<-b>, B<--blank>"
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 "Een leeg vertaald document creëren. Het gegenereerde document zal "

--- a/po/pod/pl.po
+++ b/po/pod/pl.po
@@ -2734,7 +2734,7 @@ msgstr "B<-b>, B<--blank>"
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 "Tworzy pusty przetłumaczony dokument. Podczas generowania tłumaczenia "

--- a/po/pod/po4a-pod.pot
+++ b/po/pod/po4a-pod.pot
@@ -2177,7 +2177,7 @@ msgstr ""
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 

--- a/po/pod/pt.po
+++ b/po/pod/pt.po
@@ -2841,7 +2841,7 @@ msgstr "B<-b>, B<--blank>"
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 "Criar um documento em branco traduzido. O documento gerado traduzido vai ser "

--- a/po/pod/pt_BR.po
+++ b/po/pod/pt_BR.po
@@ -2850,7 +2850,7 @@ msgstr "B<-b>, B<--blank>"
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 "Cria um documento traduzido em branco. O documento trazido gerado vai ser "

--- a/po/pod/ru.po
+++ b/po/pod/ru.po
@@ -2870,7 +2870,7 @@ msgstr "B<-b>, B<--blank>"
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 "Создаёт пустой переведённый документ. Этот документ будет создан, будто все "

--- a/po/pod/sr_Cyrl.po
+++ b/po/pod/sr_Cyrl.po
@@ -2876,7 +2876,7 @@ msgstr "B<-b>, B<--blank>"
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 "Креира празан преведени документ. То се ради тако што се усваја да су све "

--- a/po/pod/uk.po
+++ b/po/pod/uk.po
@@ -2857,7 +2857,7 @@ msgstr "B<-b>, B<--blank>"
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 "Створити порожній перекладений документ. Перекладений документ буде створено "

--- a/po/pod/zh_Hans.po
+++ b/po/pod/zh_Hans.po
@@ -2648,7 +2648,7 @@ msgstr "B<-b>, B<--blank>"
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 "创建空白翻译的文档。 如果所有消息都由空格或新行翻译，将生成生成的已翻译文档。"

--- a/po/pod/zh_Hant.po
+++ b/po/pod/zh_Hant.po
@@ -2646,7 +2646,7 @@ msgstr "B<-b>, B<--blank>"
 #. type: textblock
 #: po4a-normalize:13
 msgid ""
-"Create an blank translated document.  The generated translated document will "
+"Create a blank translated document.  The generated translated document will "
 "be generated assuming all messages are translated by a space or new line."
 msgstr ""
 "建立空白翻譯的文件。 如果所有訊息都由空格或新行翻譯，將生成生成的已翻譯文件。"

--- a/po4a-normalize
+++ b/po4a-normalize
@@ -46,11 +46,23 @@ text parser would accept '-o tabs=split'.
 
 =item B<-b>, B<--blank>
 
-Create an blank translated document.
+Create a blank translated document.
 The generated translated document will be generated assuming all messages
 are translated by a space or new line.
 
 This is useful to check what parts of the document cannot be translated.
+
+Both B<--blank> and B<--capitalize> can't be specified at the same time.
+
+=item B<-C>, B<--capitalize>
+
+Create a translated document and corresponding po-file with original strings
+translated as their capitalized versions.
+
+This is useful to check what parts of the document cannot be translated and
+generate test data for po4a.
+
+Both B<--blank> and B<--capitalize> can't be specified at the same time.
 
 =item B<-h>, B<--help>
 
@@ -124,7 +136,8 @@ sub show_version {
     exit 0;
 }
 
-my ( $blank, $help_fmt, $help, $type, $debug, $verbose, $quiet, $wrappo, @options, $no_deprecation );
+my ( $help_fmt, $help, $type, $debug, $verbose, $quiet, $wrappo, @options, $no_deprecation );
+my ( $blank, $capitalize );
 my ($mastchar);
 my ( $localized, $potfile ) = ( 'po4a-normalize.output', 'po4a-normalize.po' );
 Getopt::Long::Configure( 'no_auto_abbrev', 'no_ignore_case' );
@@ -135,7 +148,8 @@ GetOptions(
     'localized|l=s' => \$localized,
     'pot|p=s'       => \$potfile,
 
-    'blank|b' => \$blank,
+    'blank|b'      => \$blank,
+    'capitalize|C' => \$capitalize,
 
     'master-charset|M=s' => \$mastchar,
 
@@ -159,6 +173,9 @@ my %options = (
     "verbose" => $verbose,
     "debug"   => $debug,
 );
+if ($blank and $capitalize) {
+    die wrap_msg( gettext("Both B<--blank> and B<--capitalize> can't be specified at the same time."));
+}
 foreach (@options) {
     if (m/^([^=]*)=(.*)$/) {
         $options{$1} = "$2";
@@ -175,7 +192,6 @@ unless ($no_deprecation) {
         )
     );
 }
-
 my $parser = Locale::Po4a::Chooser::new( $type, %options );
 
 my $filename = shift || pod2usage(1);
@@ -186,20 +202,25 @@ $parser->read( $filename, $filename, $mastchar // '' );
 my %pot_options = ( 'wrap-po' => $wrappo );
 $parser->setpoout( Locale::Po4a::Po->new( \%pot_options ) );
 $parser->parse();
-if ($blank) {
+if ($blank or $capitalize) {
     foreach my $msgid ( keys %{ $parser->{TT}{po_out}{po} } ) {
-        if ( $msgid =~ m/\n$/s ) {
-            $parser->{TT}{po_out}{po}{$msgid}{'msgstr'} = "\n";
-        } else {
-            $parser->{TT}{po_out}{po}{$msgid}{'msgstr'} = " ";
+        if ( $blank ) {
+            if ( $msgid =~ m/\n$/s ) {
+                $parser->{TT}{po_out}{po}{$msgid}{'msgstr'} = "\n";
+            } else {
+                $parser->{TT}{po_out}{po}{$msgid}{'msgstr'} = " ";
+            }
+        } else { # $capitalize
+            ($parser->{TT}{po_out}{po}{$msgid}{'msgstr'} = $msgid) =~ s/(?<!\\)(.)/\U$1/g;
         }
     }
-    my $empty_po = $parser->{TT}{po_out};
+    my $modified_po = $parser->{TT}{po_out};
     $parser = Locale::Po4a::Chooser::new( $type, %options );
-    $parser->{TT}{po_in} = $empty_po;
-    $parser->read($filename);
+    $parser->{TT}{po_in} = $modified_po;
+    $parser->read($filename, $filename, $mastchar // '' );
     $parser->{TT}{file_in_charset} = $mastchar;
     $parser->parse();
+    $parser->{TT}{po_out} = $modified_po;
 }
 print wrap_msg( dgettext( "po4a", "Write the normalized document to %s." ), $localized )
   unless $quiet;


### PR DESCRIPTION
This is useful to create tests.

Also this PR:
- fixes a typo in the description of the neighbouring option and untypos the PO-files.
- updates "Writing a test" section in CONTRIBUTING.md