### PR TITLE
TeX: Add format test for valid input command

### DIFF
--- a/t/fmt-tex.t
+++ b/t/fmt-tex.t
@@ -20,17 +20,26 @@ foreach my $t (qw(basic theorem)) {
 
 push @tests,
   {
-    'doc'         => 'invalid input command, without ignore',
+    'doc'         => 'invalid input command (file does not exist), without ignore',
     'format'      => 'latex',
     'input'       => "fmt/tex/input-in-verbatim.tex",
     'error'       => 1,
     'norm_stderr' => 'fmt/tex/input-in-verbatim.stderr-without-ignore',
   },
   {
-    'doc'     => 'invalid input command, with exclude_include',
+    'doc'     => 'invalid input command (file does not exist), with exclude_include',
     'format'  => 'latex',
     'input'   => "fmt/tex/input-in-verbatim.tex",
     'options' => '-o exclude_include=main.tex'
+  },
+  {
+    'doc'     => 'valid input command (file exists and must be included)',
+    'format'  => 'latex',
+    'input'   => "fmt/tex/input-in-basic.tex",
+    'norm'    => "fmt/tex/input-in-basic.norm",
+    'potfile' => "fmt/tex/input-in-basic.pot",
+    'pofile'  => "fmt/tex/input-in-basic.po",
+    'trans'   => "fmt/tex/input-in-basic.trans"
   };
 
 run_all_tests(@tests);

--- a/t/fmt/tex/input-in-basic.norm
+++ b/t/fmt/tex/input-in-basic.norm
@@ -1,0 +1,10 @@
+% This file was generated with po4a. Translate the source file.
+%
+\documentclass[12pt]{article}
+\begin{document}
+
+same text in basic document
+
+same text in subtext.tex
+
+\end{document}

--- a/t/fmt/tex/input-in-basic.po
+++ b/t/fmt/tex/input-in-basic.po
@@ -1,0 +1,27 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2024-09-07 14:44+0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: document
+#: input-in-basic.tex:5
+msgid "same text in basic document"
+msgstr "SAME TEXT IN BASIC DOCUMENT"
+
+#. type: document
+#: input-in-basic.tex:7
+msgid "same text in subtext.tex"
+msgstr "SAME TEXT IN SUBTEXT.TEX"

--- a/t/fmt/tex/input-in-basic.pot
+++ b/t/fmt/tex/input-in-basic.pot
@@ -1,0 +1,27 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2024-09-07 14:44+0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: document
+#: input-in-basic.tex:5
+msgid "same text in basic document"
+msgstr ""
+
+#. type: document
+#: input-in-basic.tex:7
+msgid "same text in subtext.tex"
+msgstr ""

--- a/t/fmt/tex/input-in-basic.tex
+++ b/t/fmt/tex/input-in-basic.tex
@@ -1,0 +1,8 @@
+\documentclass[12pt]{article}
+\begin{document}
+
+same text in basic document
+
+\input{subtext.tex}
+
+\end{document}

--- a/t/fmt/tex/input-in-basic.trans
+++ b/t/fmt/tex/input-in-basic.trans
@@ -1,0 +1,10 @@
+% This file was generated with po4a. Translate the source file.
+%
+\documentclass[12pt]{article}
+\begin{document}
+
+SAME TEXT IN BASIC DOCUMENT
+
+SAME TEXT IN SUBTEXT.TEX
+
+\end{document}

--- a/t/fmt/tex/subtext.tex
+++ b/t/fmt/tex/subtext.tex
@@ -1,0 +1,1 @@
+same text in subtext.tex


### PR DESCRIPTION
Fix mquinson/po4a#521

Existing tests check invalid input command (included file not exist) and not check valid input command (included file exist and must be include). This PR fix it.

