### PR TITLE
TeX: Fix error read input/include file

### DIFF
--- a/lib/Locale/Po4a/TeX.pm
+++ b/lib/Locale/Po4a/TeX.pm
@@ -995,7 +995,7 @@ sub read_file {
 
                 # search the file
                 open( KPSEA, "kpsewhich " . $newfilename . " |" );
-                my $newfilepath = <KPSEA>;
+                chomp( my $newfilepath = <KPSEA> // '' );
 
                 if ( $newfilename ne "" and ( $newfilepath // '' ) eq '' ) {
                     die wrap_mod(


### PR DESCRIPTION
Fix mquinson/po4a#521

Using \input instruction in TeX file results in error "No such file or directory"
becouse kpsewhich return wrong filename.
This PR fix it.