### PR TITLE
Remove DynaLoader

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,7 @@ __   __/ _ \|___  | || |
 
 General:
  * Fix a failure with Perl 5.40.
+ * Remove DynaLoader (GitHub's #532) [gemmaro].
 
 TeX:
  * Fix read error of input/include files in TeX files (thanks Alex Karabanov)

--- a/lib/Locale/Po4a/Man.pm
+++ b/lib/Locale/Po4a/Man.pm
@@ -393,7 +393,6 @@ under the terms of GPL v2.0 or later (see the COPYING file).
 =cut
 
 package Locale::Po4a::Man;
-use DynaLoader;
 
 use 5.16.0;
 use strict;
@@ -401,11 +400,8 @@ use warnings;
 
 require Exporter;
 use vars qw(@ISA @EXPORT);
-@ISA    = qw(Locale::Po4a::TransTractor DynaLoader);
+@ISA    = qw(Locale::Po4a::TransTractor);
 @EXPORT = qw();                                        #  new initialize);
-
-# Try to use a C extension if present.
-eval('bootstrap Locale::Po4a::Man "0.30"');
 
 use Locale::Po4a::TransTractor;
 use Locale::Po4a::Common;

--- a/lib/Locale/Po4a/Po.pm
+++ b/lib/Locale/Po4a/Po.pm
@@ -101,20 +101,16 @@ use IO::File;
 require Exporter;
 
 package Locale::Po4a::Po;
-use DynaLoader;
 
 use Locale::Po4a::Common qw(wrap_msg wrap_mod wrap_ref_mod dgettext);
 
 use subs qw(makespace);
 use vars qw(@ISA @EXPORT_OK);
-@ISA       = qw(Exporter DynaLoader);
+@ISA       = qw(Exporter);
 @EXPORT    = qw(%debug);
 @EXPORT_OK = qw(&move_po_if_needed);
 
 use Locale::Po4a::TransTractor;
-
-# Try to use a C extension if present.
-eval("bootstrap Locale::Po4a::Po $Locale::Po4a::TransTractor::VERSION");
 
 use 5.16.0;
 use strict;

--- a/lib/Locale/Po4a/TransTractor.pm
+++ b/lib/Locale/Po4a/TransTractor.pm
@@ -3,7 +3,6 @@
 require Exporter;
 
 package Locale::Po4a::TransTractor;
-use DynaLoader;
 
 sub import { }
 
@@ -12,15 +11,11 @@ use strict;
 use warnings;
 
 use subs qw(makespace);
-use vars qw($VERSION @ISA @EXPORT);
+use vars qw($VERSION @EXPORT);
 $VERSION = "0.74-alpha";
-@ISA     = qw(DynaLoader);
 @EXPORT  = qw(new process translate
   read write readpo writepo
   getpoout setpoout get_in_charset get_out_charset handle_yaml);
-
-# Try to use a C extension if present.
-eval("bootstrap Locale::Po4a::TransTractor $VERSION");
 
 use Carp qw(croak confess);
 use Locale::Po4a::Po;


### PR DESCRIPTION
This removes DynaLoader from some is-a relationships.

DynaLoader was introduced in 0a4e526ddd3a3a5e9cc92f1832833d21a37b314c, but was removed in dbbc6d2c763ce89a13af003871ecffa01a8edc30 long time ago.  So it should be safe to remove it now.