### PR TITLE
Clean up modules' exporting/importing symbols

### DIFF
--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -31,7 +31,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw();
 
-use Locale::Po4a::Common qw(wrap_mod);
+use Locale::Po4a::Common qw(wrap_mod dgettext);
 use YAML::Tiny;
 
 =head1 OPTIONS ACCEPTED BY THIS MODULE

--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -31,7 +31,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw();
 
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_mod);
 use YAML::Tiny;
 
 =head1 OPTIONS ACCEPTED BY THIS MODULE

--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -27,10 +27,6 @@ use warnings;
 
 use parent qw(Locale::Po4a::TransTractor);
 
-require Exporter;
-use vars qw(@EXPORT);
-@EXPORT = qw();
-
 use Locale::Po4a::Common qw(wrap_mod dgettext);
 use YAML::Tiny;
 

--- a/lib/Locale/Po4a/BibTeX.pm
+++ b/lib/Locale/Po4a/BibTeX.pm
@@ -56,10 +56,6 @@ use warnings;
 
 use parent qw(Locale::Po4a::TransTractor);
 
-require Exporter;
-use vars qw(@EXPORT);
-@EXPORT = qw();
-
 use Locale::Po4a::Common;
 
 sub parse {

--- a/lib/Locale/Po4a/BibTeX.pm
+++ b/lib/Locale/Po4a/BibTeX.pm
@@ -62,8 +62,6 @@ use vars qw(@EXPORT);
 
 use Locale::Po4a::Common;
 
-sub initialize { }
-
 sub parse {
     my $self = shift;
     my ( $line, $ref );

--- a/lib/Locale/Po4a/Chooser.pm
+++ b/lib/Locale/Po4a/Chooser.pm
@@ -16,7 +16,7 @@ package Locale::Po4a::Chooser;
 use 5.16.0;
 use strict;
 use warnings;
-use Locale::Po4a::Common qw(wrap_msg);
+use Locale::Po4a::Common qw(wrap_msg wrap_mod);
 
 sub new {
     my ($module)  = shift;

--- a/lib/Locale/Po4a/Chooser.pm
+++ b/lib/Locale/Po4a/Chooser.pm
@@ -16,7 +16,7 @@ package Locale::Po4a::Chooser;
 use 5.16.0;
 use strict;
 use warnings;
-use Locale::Po4a::Common qw(wrap_msg wrap_mod);
+use Locale::Po4a::Common qw(wrap_msg wrap_mod gettext);
 
 sub new {
     my ($module)  = shift;

--- a/lib/Locale/Po4a/Chooser.pm
+++ b/lib/Locale/Po4a/Chooser.pm
@@ -16,7 +16,7 @@ package Locale::Po4a::Chooser;
 use 5.16.0;
 use strict;
 use warnings;
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_msg);
 
 sub new {
     my ($module)  = shift;

--- a/lib/Locale/Po4a/Common.pm
+++ b/lib/Locale/Po4a/Common.pm
@@ -41,7 +41,7 @@ use warnings;
 use parent qw(Exporter);
 
 use vars qw(@EXPORT);
-@EXPORT = qw(wrap_msg wrap_mod wrap_ref_mod textdomain gettext dgettext);
+@EXPORT = qw(wrap_msg wrap_mod wrap_ref_mod gettext dgettext);
 
 sub import {
     my $class = shift;

--- a/lib/Locale/Po4a/Common.pm
+++ b/lib/Locale/Po4a/Common.pm
@@ -39,9 +39,7 @@ use strict;
 use warnings;
 
 use parent qw(Exporter);
-
-our @EXPORT = qw(dgettext);
-our @EXPORT_OK = qw(wrap_msg wrap_mod wrap_ref_mod gettext);
+our @EXPORT_OK = qw(wrap_msg wrap_mod wrap_ref_mod gettext dgettext);
 
 sub import {
     my $class = shift;

--- a/lib/Locale/Po4a/Common.pm
+++ b/lib/Locale/Po4a/Common.pm
@@ -40,8 +40,8 @@ use warnings;
 
 use parent qw(Exporter);
 
-our @EXPORT = qw(gettext dgettext);
-our @EXPORT_OK = qw(wrap_msg wrap_mod wrap_ref_mod);
+our @EXPORT = qw(dgettext);
+our @EXPORT_OK = qw(wrap_msg wrap_mod wrap_ref_mod gettext);
 
 sub import {
     my $class = shift;

--- a/lib/Locale/Po4a/Common.pm
+++ b/lib/Locale/Po4a/Common.pm
@@ -40,8 +40,8 @@ use warnings;
 
 use parent qw(Exporter);
 
-use vars qw(@EXPORT);
-@EXPORT = qw(wrap_msg wrap_mod wrap_ref_mod gettext dgettext);
+our @EXPORT = qw(wrap_mod wrap_ref_mod gettext dgettext);
+our @EXPORT_OK = qw(wrap_msg);
 
 sub import {
     my $class = shift;

--- a/lib/Locale/Po4a/Common.pm
+++ b/lib/Locale/Po4a/Common.pm
@@ -40,8 +40,8 @@ use warnings;
 
 use parent qw(Exporter);
 
-our @EXPORT = qw(wrap_ref_mod gettext dgettext);
-our @EXPORT_OK = qw(wrap_msg wrap_mod);
+our @EXPORT = qw(gettext dgettext);
+our @EXPORT_OK = qw(wrap_msg wrap_mod wrap_ref_mod);
 
 sub import {
     my $class = shift;

--- a/lib/Locale/Po4a/Common.pm
+++ b/lib/Locale/Po4a/Common.pm
@@ -40,8 +40,8 @@ use warnings;
 
 use parent qw(Exporter);
 
-our @EXPORT = qw(wrap_mod wrap_ref_mod gettext dgettext);
-our @EXPORT_OK = qw(wrap_msg);
+our @EXPORT = qw(wrap_ref_mod gettext dgettext);
+our @EXPORT_OK = qw(wrap_msg wrap_mod);
 
 sub import {
     my $class = shift;

--- a/lib/Locale/Po4a/Gemtext.pm
+++ b/lib/Locale/Po4a/Gemtext.pm
@@ -53,8 +53,6 @@ other [human] languages.
 
 =cut
 
-sub initialize { }
-
 sub parse {
     my $self = shift;
 

--- a/lib/Locale/Po4a/Gemtext.pm
+++ b/lib/Locale/Po4a/Gemtext.pm
@@ -29,10 +29,7 @@ use warnings;
 
 use parent qw(Locale::Po4a::TransTractor);
 
-require Exporter;
-
-use vars qw(@EXPORT @AUTOLOAD);
-@EXPORT = qw();
+use vars qw(@AUTOLOAD);
 
 use Locale::Po4a::Common;
 

--- a/lib/Locale/Po4a/Halibut.pm
+++ b/lib/Locale/Po4a/Halibut.pm
@@ -82,11 +82,8 @@ use strict;
 use warnings;
 
 use parent qw(Locale::Po4a::TeX);
-
-require Exporter;
-use vars qw($VERSION @EXPORT);
+use vars qw($VERSION);
 $VERSION = $Locale::Po4a::TeX::VERSION;
-@EXPORT  = qw();
 
 use Locale::Po4a::Common;
 use subs qw(&parse_definition_file

--- a/lib/Locale/Po4a/InProgress/Debconf.pm
+++ b/lib/Locale/Po4a/InProgress/Debconf.pm
@@ -69,7 +69,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw();
 
-use Locale::Po4a::Common qw(wrap_mod);
+use Locale::Po4a::Common qw(wrap_mod dgettext);
 
 sub initialize { }
 

--- a/lib/Locale/Po4a/InProgress/Debconf.pm
+++ b/lib/Locale/Po4a/InProgress/Debconf.pm
@@ -71,8 +71,6 @@ use vars qw(@EXPORT);
 
 use Locale::Po4a::Common qw(wrap_mod dgettext);
 
-sub initialize { }
-
 sub parse {
     my $self = shift;
 

--- a/lib/Locale/Po4a/InProgress/Debconf.pm
+++ b/lib/Locale/Po4a/InProgress/Debconf.pm
@@ -65,10 +65,6 @@ use warnings;
 
 use parent qw(Locale::Po4a::TransTractor);
 
-require Exporter;
-use vars qw(@EXPORT);
-@EXPORT = qw();
-
 use Locale::Po4a::Common qw(wrap_mod dgettext);
 
 sub parse {

--- a/lib/Locale/Po4a/InProgress/Debconf.pm
+++ b/lib/Locale/Po4a/InProgress/Debconf.pm
@@ -69,7 +69,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw();
 
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_mod);
 
 sub initialize { }
 

--- a/lib/Locale/Po4a/InProgress/NewsDebian.pm
+++ b/lib/Locale/Po4a/InProgress/NewsDebian.pm
@@ -59,10 +59,6 @@ use warnings;
 
 use parent qw(Locale::Po4a::TransTractor);
 
-require Exporter;
-use vars qw(@EXPORT);
-@EXPORT = qw();
-
 use Locale::Po4a::Common qw(wrap_ref_mod dgettext);
 
 sub parse {

--- a/lib/Locale/Po4a/InProgress/NewsDebian.pm
+++ b/lib/Locale/Po4a/InProgress/NewsDebian.pm
@@ -63,7 +63,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw();
 
-use Locale::Po4a::Common qw(wrap_ref_mod);
+use Locale::Po4a::Common qw(wrap_ref_mod dgettext);
 
 sub initialize { }
 

--- a/lib/Locale/Po4a/InProgress/NewsDebian.pm
+++ b/lib/Locale/Po4a/InProgress/NewsDebian.pm
@@ -63,7 +63,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw();
 
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_ref_mod);
 
 sub initialize { }
 

--- a/lib/Locale/Po4a/InProgress/NewsDebian.pm
+++ b/lib/Locale/Po4a/InProgress/NewsDebian.pm
@@ -65,8 +65,6 @@ use vars qw(@EXPORT);
 
 use Locale::Po4a::Common qw(wrap_ref_mod dgettext);
 
-sub initialize { }
-
 sub parse {
     my $self = shift;
 

--- a/lib/Locale/Po4a/Ini.pm
+++ b/lib/Locale/Po4a/Ini.pm
@@ -18,10 +18,7 @@ use parent qw(Locale::Po4a::TransTractor);
 
 use Locale::Po4a::Common;
 
-require Exporter;
-
-use vars qw(@EXPORT $AUTOLOAD);
-@EXPORT = qw();
+use vars qw($AUTOLOAD);
 
 my $debug = 0;
 

--- a/lib/Locale/Po4a/Ini.pm
+++ b/lib/Locale/Po4a/Ini.pm
@@ -25,8 +25,6 @@ use vars qw(@EXPORT $AUTOLOAD);
 
 my $debug = 0;
 
-sub initialize { }
-
 sub parse {
     my $self = shift;
     my ( $line, $ref );

--- a/lib/Locale/Po4a/KernelHelp.pm
+++ b/lib/Locale/Po4a/KernelHelp.pm
@@ -20,10 +20,7 @@ use parent qw(Locale::Po4a::TransTractor);
 use Pod::Parser;
 use Locale::Po4a::Common qw(wrap_ref_mod gettext);
 
-require Exporter;
-
-use vars qw(@EXPORT $AUTOLOAD);
-@EXPORT = qw();    # new process write read writepo readpo);
+use vars qw($AUTOLOAD);
 
 my $debug = 0;
 

--- a/lib/Locale/Po4a/KernelHelp.pm
+++ b/lib/Locale/Po4a/KernelHelp.pm
@@ -18,7 +18,7 @@ use warnings;
 use parent qw(Locale::Po4a::TransTractor);
 
 use Pod::Parser;
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_ref_mod);
 
 require Exporter;
 

--- a/lib/Locale/Po4a/KernelHelp.pm
+++ b/lib/Locale/Po4a/KernelHelp.pm
@@ -18,7 +18,7 @@ use warnings;
 use parent qw(Locale::Po4a::TransTractor);
 
 use Pod::Parser;
-use Locale::Po4a::Common qw(wrap_ref_mod);
+use Locale::Po4a::Common qw(wrap_ref_mod gettext);
 
 require Exporter;
 

--- a/lib/Locale/Po4a/KernelHelp.pm
+++ b/lib/Locale/Po4a/KernelHelp.pm
@@ -27,8 +27,6 @@ use vars qw(@EXPORT $AUTOLOAD);
 
 my $debug = 0;
 
-sub initialize { }
-
 sub parse {
     my $self = shift;
     my ( $line, $ref );

--- a/lib/Locale/Po4a/LaTeX.pm
+++ b/lib/Locale/Po4a/LaTeX.pm
@@ -69,11 +69,8 @@ use strict;
 use warnings;
 
 use parent qw(Locale::Po4a::TeX);
-
-require Exporter;
-use vars qw($VERSION @EXPORT);
+use vars qw($VERSION);
 $VERSION = $Locale::Po4a::TeX::VERSION;
-@EXPORT  = qw();
 
 use subs qw(&generic_command
   &parse_definition_file

--- a/lib/Locale/Po4a/Man.pm
+++ b/lib/Locale/Po4a/Man.pm
@@ -404,7 +404,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw();    #  new initialize);
 
-use Locale::Po4a::Common qw(wrap_mod);
+use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod);
 
 use File::Spec;
 use Getopt::Std;

--- a/lib/Locale/Po4a/Man.pm
+++ b/lib/Locale/Po4a/Man.pm
@@ -400,10 +400,6 @@ use warnings;
 
 use parent qw(Locale::Po4a::TransTractor);
 
-require Exporter;
-use vars qw(@EXPORT);
-@EXPORT = qw();    #  new initialize);
-
 use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod dgettext);
 
 use File::Spec;

--- a/lib/Locale/Po4a/Man.pm
+++ b/lib/Locale/Po4a/Man.pm
@@ -404,7 +404,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw();    #  new initialize);
 
-use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod);
+use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod dgettext);
 
 use File::Spec;
 use Getopt::Std;

--- a/lib/Locale/Po4a/Man.pm
+++ b/lib/Locale/Po4a/Man.pm
@@ -404,7 +404,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw();    #  new initialize);
 
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_mod);
 
 use File::Spec;
 use Getopt::Std;

--- a/lib/Locale/Po4a/Org.pm
+++ b/lib/Locale/Po4a/Org.pm
@@ -29,7 +29,7 @@ use warnings;
 
 use parent qw(Locale::Po4a::TransTractor);
 
-use Locale::Po4a::Common qw(wrap_mod);
+use Locale::Po4a::Common qw(wrap_mod dgettext);
 
 sub initialize {
     my ( $self, %options ) = @_;

--- a/lib/Locale/Po4a/Org.pm
+++ b/lib/Locale/Po4a/Org.pm
@@ -29,6 +29,8 @@ use warnings;
 
 use parent qw(Locale::Po4a::TransTractor);
 
+use Locale::Po4a::Common qw(wrap_mod);
+
 sub initialize {
     my ( $self, %options ) = @_;
 

--- a/lib/Locale/Po4a/Po.pm
+++ b/lib/Locale/Po4a/Po.pm
@@ -103,15 +103,13 @@ use strict;
 use warnings;
 
 use parent qw(Exporter);
+our @EXPORT_OK = qw(move_po_if_needed);
 
 use IO::File;
 
 use Locale::Po4a::Common qw(wrap_msg wrap_mod wrap_ref_mod dgettext);
 
 use subs qw(makespace);
-use vars qw(@EXPORT @EXPORT_OK);
-@EXPORT    = qw(%debug);
-@EXPORT_OK = qw(&move_po_if_needed);
 
 use Locale::Po4a::TransTractor;
 

--- a/lib/Locale/Po4a/Po.pm
+++ b/lib/Locale/Po4a/Po.pm
@@ -111,8 +111,6 @@ use Locale::Po4a::Common qw(wrap_msg wrap_mod wrap_ref_mod dgettext);
 
 use subs qw(makespace);
 
-use Locale::Po4a::TransTractor;
-
 use Carp qw(croak);
 use File::Basename;
 use File::Path;    # mkdir before write

--- a/lib/Locale/Po4a/Pod.pm
+++ b/lib/Locale/Po4a/Pod.pm
@@ -23,7 +23,7 @@ require Exporter;
 
 use Carp qw(croak confess);
 
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_mod);
 
 sub initialize { }
 

--- a/lib/Locale/Po4a/Pod.pm
+++ b/lib/Locale/Po4a/Pod.pm
@@ -19,8 +19,6 @@ use warnings;
 
 use parent qw(Locale::Po4a::TransTractor Pod::Parser);
 
-require Exporter;
-
 use Carp qw(croak confess);
 
 use Locale::Po4a::Common qw(wrap_mod dgettext);

--- a/lib/Locale/Po4a/Pod.pm
+++ b/lib/Locale/Po4a/Pod.pm
@@ -25,8 +25,6 @@ use Carp qw(croak confess);
 
 use Locale::Po4a::Common qw(wrap_mod dgettext);
 
-sub initialize { }
-
 sub translate {
     my ( $self, $str, $ref, $type ) = @_;
     my (%options) = @_;

--- a/lib/Locale/Po4a/Pod.pm
+++ b/lib/Locale/Po4a/Pod.pm
@@ -23,7 +23,7 @@ require Exporter;
 
 use Carp qw(croak confess);
 
-use Locale::Po4a::Common qw(wrap_mod);
+use Locale::Po4a::Common qw(wrap_mod dgettext);
 
 sub initialize { }
 

--- a/lib/Locale/Po4a/RubyDoc.pm
+++ b/lib/Locale/Po4a/RubyDoc.pm
@@ -48,7 +48,7 @@ use warnings;
 
 use parent qw(Locale::Po4a::TransTractor);
 
-use Locale::Po4a::Common qw(wrap_mod);
+use Locale::Po4a::Common qw(wrap_mod dgettext);
 
 require Exporter;
 

--- a/lib/Locale/Po4a/RubyDoc.pm
+++ b/lib/Locale/Po4a/RubyDoc.pm
@@ -48,7 +48,7 @@ use warnings;
 
 use parent qw(Locale::Po4a::TransTractor);
 
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_mod);
 
 require Exporter;
 

--- a/lib/Locale/Po4a/RubyDoc.pm
+++ b/lib/Locale/Po4a/RubyDoc.pm
@@ -50,8 +50,6 @@ use parent qw(Locale::Po4a::TransTractor);
 
 use Locale::Po4a::Common qw(wrap_mod dgettext);
 
-require Exporter;
-
 ######################
 #  Global variables  #
 ######################

--- a/lib/Locale/Po4a/Sgml.pm
+++ b/lib/Locale/Po4a/Sgml.pm
@@ -217,7 +217,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw();
 
-use Locale::Po4a::Common qw(wrap_mod);
+use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod);
 
 eval qq{use SGMLS};
 if ($@) {

--- a/lib/Locale/Po4a/Sgml.pm
+++ b/lib/Locale/Po4a/Sgml.pm
@@ -213,10 +213,6 @@ use warnings;
 
 use parent qw(Locale::Po4a::TransTractor);
 
-require Exporter;
-use vars qw(@EXPORT);
-@EXPORT = qw();
-
 use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod dgettext);
 
 eval qq{use SGMLS};

--- a/lib/Locale/Po4a/Sgml.pm
+++ b/lib/Locale/Po4a/Sgml.pm
@@ -217,7 +217,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw();
 
-use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod);
+use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod dgettext);
 
 eval qq{use SGMLS};
 if ($@) {

--- a/lib/Locale/Po4a/Sgml.pm
+++ b/lib/Locale/Po4a/Sgml.pm
@@ -217,7 +217,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw();
 
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_mod);
 
 eval qq{use SGMLS};
 if ($@) {

--- a/lib/Locale/Po4a/TeX.pm
+++ b/lib/Locale/Po4a/TeX.pm
@@ -64,20 +64,6 @@ use warnings;
 
 use parent qw(Locale::Po4a::TransTractor);
 
-require Exporter;
-use vars qw(@EXPORT);
-@EXPORT = qw(%commands %environments
-  $RE_ESCAPE $ESCAPE $RE_VERBATIM
-  $no_wrap_environments
-  $verbatim_environments
-  %separated_command
-  %separated_environment
-  %translate_buffer_env
-  &add_comment
-  &generic_command
-  &register_generic_command
-  &register_generic_environment);
-
 use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod dgettext);
 use File::Basename qw(dirname);
 use Carp           qw(croak);

--- a/lib/Locale/Po4a/TeX.pm
+++ b/lib/Locale/Po4a/TeX.pm
@@ -78,7 +78,7 @@ use vars qw(@EXPORT);
   &register_generic_command
   &register_generic_environment);
 
-use Locale::Po4a::Common qw(wrap_mod);
+use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod);
 use File::Basename qw(dirname);
 use Carp           qw(croak);
 

--- a/lib/Locale/Po4a/TeX.pm
+++ b/lib/Locale/Po4a/TeX.pm
@@ -78,7 +78,7 @@ use vars qw(@EXPORT);
   &register_generic_command
   &register_generic_environment);
 
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_mod);
 use File::Basename qw(dirname);
 use Carp           qw(croak);
 

--- a/lib/Locale/Po4a/TeX.pm
+++ b/lib/Locale/Po4a/TeX.pm
@@ -78,7 +78,7 @@ use vars qw(@EXPORT);
   &register_generic_command
   &register_generic_environment);
 
-use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod);
+use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod dgettext);
 use File::Basename qw(dirname);
 use Carp           qw(croak);
 

--- a/lib/Locale/Po4a/Texinfo.pm
+++ b/lib/Locale/Po4a/Texinfo.pm
@@ -84,10 +84,8 @@ use warnings;
 
 use parent qw(Locale::Po4a::TeX);
 
-require Exporter;
-use vars qw($VERSION @EXPORT);
+use vars qw($VERSION);
 $VERSION = $Locale::Po4a::TeX::VERSION;
-@EXPORT  = qw();
 
 use Locale::Po4a::Common;
 use subs qw(

--- a/lib/Locale/Po4a/Text.pm
+++ b/lib/Locale/Po4a/Text.pm
@@ -56,7 +56,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw();
 
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_mod);
 use YAML::Tiny;
 use Syntax::Keyword::Try;
 

--- a/lib/Locale/Po4a/Text.pm
+++ b/lib/Locale/Po4a/Text.pm
@@ -52,10 +52,6 @@ use warnings;
 
 use parent qw(Locale::Po4a::TransTractor);
 
-require Exporter;
-use vars qw(@EXPORT);
-@EXPORT = qw();
-
 use Locale::Po4a::Common qw(wrap_mod dgettext);
 use YAML::Tiny;
 use Syntax::Keyword::Try;

--- a/lib/Locale/Po4a/Text.pm
+++ b/lib/Locale/Po4a/Text.pm
@@ -56,7 +56,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw();
 
-use Locale::Po4a::Common qw(wrap_mod);
+use Locale::Po4a::Common qw(wrap_mod dgettext);
 use YAML::Tiny;
 use Syntax::Keyword::Try;
 

--- a/lib/Locale/Po4a/TransTractor.pm
+++ b/lib/Locale/Po4a/TransTractor.pm
@@ -1,21 +1,14 @@
 #!/usr/bin/perl -w
 
-require Exporter;
-
 package Locale::Po4a::TransTractor;
-
-sub import { }
 
 use 5.16.0;
 use strict;
 use warnings;
 
 use subs qw(makespace);
-use vars qw($VERSION @EXPORT);
+use vars qw($VERSION);
 $VERSION = "0.74-alpha";
-@EXPORT  = qw(new process translate
-  read write readpo writepo
-  getpoout setpoout get_in_charset get_out_charset handle_yaml);
 
 use Carp qw(croak confess);
 use Locale::Po4a::Po;

--- a/lib/Locale/Po4a/TransTractor.pm
+++ b/lib/Locale/Po4a/TransTractor.pm
@@ -19,7 +19,7 @@ $VERSION = "0.74-alpha";
 
 use Carp qw(croak confess);
 use Locale::Po4a::Po;
-use Locale::Po4a::Common qw(wrap_msg);
+use Locale::Po4a::Common qw(wrap_msg wrap_mod);
 
 use File::Path;    # mkdir before write
 use File::Spec;

--- a/lib/Locale/Po4a/TransTractor.pm
+++ b/lib/Locale/Po4a/TransTractor.pm
@@ -19,7 +19,7 @@ $VERSION = "0.74-alpha";
 
 use Carp qw(croak confess);
 use Locale::Po4a::Po;
-use Locale::Po4a::Common qw(wrap_msg wrap_mod gettext);
+use Locale::Po4a::Common qw(wrap_msg wrap_mod gettext dgettext);
 
 use File::Path;    # mkdir before write
 use File::Spec;

--- a/lib/Locale/Po4a/TransTractor.pm
+++ b/lib/Locale/Po4a/TransTractor.pm
@@ -19,7 +19,7 @@ $VERSION = "0.74-alpha";
 
 use Carp qw(croak confess);
 use Locale::Po4a::Po;
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_msg);
 
 use File::Path;    # mkdir before write
 use File::Spec;

--- a/lib/Locale/Po4a/TransTractor.pm
+++ b/lib/Locale/Po4a/TransTractor.pm
@@ -405,6 +405,8 @@ sub new {
     return $self;
 }
 
+sub initialize { }
+
 =back
 
 =head2 Manipulating document files

--- a/lib/Locale/Po4a/TransTractor.pm
+++ b/lib/Locale/Po4a/TransTractor.pm
@@ -19,7 +19,7 @@ $VERSION = "0.74-alpha";
 
 use Carp qw(croak confess);
 use Locale::Po4a::Po;
-use Locale::Po4a::Common qw(wrap_msg wrap_mod);
+use Locale::Po4a::Common qw(wrap_msg wrap_mod gettext);
 
 use File::Path;    # mkdir before write
 use File::Spec;

--- a/lib/Locale/Po4a/Wml.pm
+++ b/lib/Locale/Po4a/Wml.pm
@@ -64,10 +64,6 @@ use warnings;
 
 use parent qw(Locale::Po4a::Xhtml);
 
-require Exporter;
-use vars qw(@EXPORT);
-@EXPORT = qw();
-
 use Locale::Po4a::Common qw(wrap_msg gettext);
 use File::Temp;
 

--- a/lib/Locale/Po4a/Wml.pm
+++ b/lib/Locale/Po4a/Wml.pm
@@ -68,7 +68,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw();
 
-use Locale::Po4a::Common qw(wrap_msg);
+use Locale::Po4a::Common qw(wrap_msg gettext);
 use File::Temp;
 
 sub initialize {

--- a/lib/Locale/Po4a/Wml.pm
+++ b/lib/Locale/Po4a/Wml.pm
@@ -68,7 +68,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw();
 
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_msg);
 use File::Temp;
 
 sub initialize {

--- a/lib/Locale/Po4a/Xhtml.pm
+++ b/lib/Locale/Po4a/Xhtml.pm
@@ -98,7 +98,7 @@ use parent qw(Locale::Po4a::Xml);
 use vars qw(@tag_types);
 *tag_types = \@Locale::Po4a::Xml::tag_types;
 
-use Locale::Po4a::Common qw(wrap_mod);
+use Locale::Po4a::Common qw(wrap_mod dgettext);
 use Carp qw(croak);
 
 sub tag_extract_SSI {

--- a/lib/Locale/Po4a/Xhtml.pm
+++ b/lib/Locale/Po4a/Xhtml.pm
@@ -98,7 +98,7 @@ use parent qw(Locale::Po4a::Xml);
 use vars qw(@tag_types);
 *tag_types = \@Locale::Po4a::Xml::tag_types;
 
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_mod);
 use Carp qw(croak);
 
 sub tag_extract_SSI {

--- a/lib/Locale/Po4a/Xhtml.pm
+++ b/lib/Locale/Po4a/Xhtml.pm
@@ -241,3 +241,5 @@ sub initialize {
         }
     }
 }
+
+1;

--- a/lib/Locale/Po4a/Xml.pm
+++ b/lib/Locale/Po4a/Xml.pm
@@ -58,7 +58,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw(new initialize @tag_types);
 
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_mod);
 use Carp qw(croak);
 use File::Basename;
 use File::Spec;

--- a/lib/Locale/Po4a/Xml.pm
+++ b/lib/Locale/Po4a/Xml.pm
@@ -52,8 +52,7 @@ use 5.16.0;
 use strict;
 use warnings;
 
-use parent qw(Locale::Po4a::TransTractor Exporter);
-our @EXPORT = qw(initialize);
+use parent qw(Locale::Po4a::TransTractor);
 
 use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod dgettext);
 use Carp qw(croak);

--- a/lib/Locale/Po4a/Xml.pm
+++ b/lib/Locale/Po4a/Xml.pm
@@ -58,7 +58,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw(new initialize @tag_types);
 
-use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod);
+use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod dgettext);
 use Carp qw(croak);
 use File::Basename;
 use File::Spec;

--- a/lib/Locale/Po4a/Xml.pm
+++ b/lib/Locale/Po4a/Xml.pm
@@ -58,7 +58,7 @@ require Exporter;
 use vars qw(@EXPORT);
 @EXPORT = qw(new initialize @tag_types);
 
-use Locale::Po4a::Common qw(wrap_mod);
+use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod);
 use Carp qw(croak);
 use File::Basename;
 use File::Spec;

--- a/lib/Locale/Po4a/Xml.pm
+++ b/lib/Locale/Po4a/Xml.pm
@@ -52,11 +52,8 @@ use 5.16.0;
 use strict;
 use warnings;
 
-use parent qw(Locale::Po4a::TransTractor);
-
-require Exporter;
-use vars qw(@EXPORT);
-@EXPORT = qw(new initialize @tag_types);
+use parent qw(Locale::Po4a::TransTractor Exporter);
+our @EXPORT = qw(initialize @tag_types);
 
 use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod dgettext);
 use Carp qw(croak);

--- a/lib/Locale/Po4a/Xml.pm
+++ b/lib/Locale/Po4a/Xml.pm
@@ -53,7 +53,7 @@ use strict;
 use warnings;
 
 use parent qw(Locale::Po4a::TransTractor Exporter);
-our @EXPORT = qw(initialize @tag_types);
+our @EXPORT = qw(initialize);
 
 use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod dgettext);
 use Carp qw(croak);

--- a/lib/Locale/Po4a/Yaml.pm
+++ b/lib/Locale/Po4a/Yaml.pm
@@ -80,7 +80,7 @@ use warnings;
 
 use parent qw(Locale::Po4a::TransTractor);
 
-use Locale::Po4a::Common qw(wrap_mod);
+use Locale::Po4a::Common qw(wrap_mod dgettext);
 use YAML::Tiny;
 use Scalar::Util;
 use Encode;

--- a/lib/Locale/Po4a/Yaml.pm
+++ b/lib/Locale/Po4a/Yaml.pm
@@ -85,10 +85,7 @@ use YAML::Tiny;
 use Scalar::Util;
 use Encode;
 
-require Exporter;
-
-use vars qw(@EXPORT $AUTOLOAD);
-@EXPORT = qw();
+use vars qw($AUTOLOAD);
 
 my %yfm_keys  = ();
 my %yfm_paths = ();

--- a/lib/Locale/Po4a/Yaml.pm
+++ b/lib/Locale/Po4a/Yaml.pm
@@ -80,7 +80,7 @@ use warnings;
 
 use parent qw(Locale::Po4a::TransTractor);
 
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_mod);
 use YAML::Tiny;
 use Scalar::Util;
 use Encode;

--- a/msguntypot
+++ b/msguntypot
@@ -116,7 +116,7 @@ use warnings;
 use Getopt::Long qw(GetOptions);
 
 use Locale::Po4a::TransTractor;
-use Locale::Po4a::Common qw(wrap_msg);
+use Locale::Po4a::Common qw(wrap_msg gettext);
 
 use Pod::Usage qw(pod2usage);
 

--- a/msguntypot
+++ b/msguntypot
@@ -116,7 +116,7 @@ use warnings;
 use Getopt::Long qw(GetOptions);
 
 use Locale::Po4a::TransTractor;
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_msg);
 
 use Pod::Usage qw(pod2usage);
 

--- a/po4a
+++ b/po4a
@@ -706,7 +706,7 @@ use Getopt::Long qw(GetOptions);
 
 use Locale::Po4a::Chooser;
 use Locale::Po4a::TransTractor;
-use Locale::Po4a::Common qw(wrap_msg wrap_ref_mod);
+use Locale::Po4a::Common qw(wrap_msg wrap_ref_mod gettext);
 use Locale::Po4a::Po qw(move_po_if_needed);
 
 use Pod::Usage qw(pod2usage);

--- a/po4a
+++ b/po4a
@@ -706,7 +706,7 @@ use Getopt::Long qw(GetOptions);
 
 use Locale::Po4a::Chooser;
 use Locale::Po4a::TransTractor;
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_msg);
 use Locale::Po4a::Po qw(move_po_if_needed);
 
 use Pod::Usage qw(pod2usage);

--- a/po4a
+++ b/po4a
@@ -706,7 +706,7 @@ use Getopt::Long qw(GetOptions);
 
 use Locale::Po4a::Chooser;
 use Locale::Po4a::TransTractor;
-use Locale::Po4a::Common qw(wrap_msg);
+use Locale::Po4a::Common qw(wrap_msg wrap_ref_mod);
 use Locale::Po4a::Po qw(move_po_if_needed);
 
 use Pod::Usage qw(pod2usage);

--- a/po4a
+++ b/po4a
@@ -706,7 +706,7 @@ use Getopt::Long qw(GetOptions);
 
 use Locale::Po4a::Chooser;
 use Locale::Po4a::TransTractor;
-use Locale::Po4a::Common qw(wrap_msg wrap_ref_mod gettext);
+use Locale::Po4a::Common qw(wrap_msg wrap_ref_mod gettext dgettext);
 use Locale::Po4a::Po qw(move_po_if_needed);
 
 use Pod::Usage qw(pod2usage);

--- a/po4a-gettextize
+++ b/po4a-gettextize
@@ -344,7 +344,7 @@ use Getopt::Long qw(GetOptions);
 
 use Locale::Po4a::Chooser;
 use Locale::Po4a::TransTractor;
-use Locale::Po4a::Common qw(wrap_msg wrap_mod);
+use Locale::Po4a::Common qw(wrap_msg wrap_mod gettext);
 
 use Pod::Usage qw(pod2usage);
 

--- a/po4a-gettextize
+++ b/po4a-gettextize
@@ -344,7 +344,7 @@ use Getopt::Long qw(GetOptions);
 
 use Locale::Po4a::Chooser;
 use Locale::Po4a::TransTractor;
-use Locale::Po4a::Common qw(wrap_msg wrap_mod gettext);
+use Locale::Po4a::Common qw(wrap_msg wrap_mod gettext dgettext);
 
 use Pod::Usage qw(pod2usage);
 

--- a/po4a-gettextize
+++ b/po4a-gettextize
@@ -344,7 +344,7 @@ use Getopt::Long qw(GetOptions);
 
 use Locale::Po4a::Chooser;
 use Locale::Po4a::TransTractor;
-use Locale::Po4a::Common qw(wrap_msg);
+use Locale::Po4a::Common qw(wrap_msg wrap_mod);
 
 use Pod::Usage qw(pod2usage);
 

--- a/po4a-gettextize
+++ b/po4a-gettextize
@@ -344,7 +344,7 @@ use Getopt::Long qw(GetOptions);
 
 use Locale::Po4a::Chooser;
 use Locale::Po4a::TransTractor;
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_msg);
 
 use Pod::Usage qw(pod2usage);
 

--- a/po4a-normalize
+++ b/po4a-normalize
@@ -129,7 +129,7 @@ use warnings;
 
 use Locale::Po4a::Chooser;
 use Locale::Po4a::TransTractor;
-use Locale::Po4a::Common qw(wrap_msg gettext);
+use Locale::Po4a::Common qw(wrap_msg gettext dgettext);
 
 use Getopt::Long qw(GetOptions);
 

--- a/po4a-normalize
+++ b/po4a-normalize
@@ -129,7 +129,7 @@ use warnings;
 
 use Locale::Po4a::Chooser;
 use Locale::Po4a::TransTractor;
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_msg);
 
 use Getopt::Long qw(GetOptions);
 

--- a/po4a-normalize
+++ b/po4a-normalize
@@ -129,7 +129,7 @@ use warnings;
 
 use Locale::Po4a::Chooser;
 use Locale::Po4a::TransTractor;
-use Locale::Po4a::Common qw(wrap_msg);
+use Locale::Po4a::Common qw(wrap_msg gettext);
 
 use Getopt::Long qw(GetOptions);
 

--- a/po4a-translate
+++ b/po4a-translate
@@ -175,7 +175,7 @@ use warnings;
 
 use Locale::Po4a::Chooser;
 use Locale::Po4a::TransTractor;
-use Locale::Po4a::Common qw(wrap_msg);
+use Locale::Po4a::Common qw(wrap_msg gettext);
 
 use Pod::Usage   qw(pod2usage);
 use Getopt::Long qw(GetOptions);

--- a/po4a-translate
+++ b/po4a-translate
@@ -175,7 +175,7 @@ use warnings;
 
 use Locale::Po4a::Chooser;
 use Locale::Po4a::TransTractor;
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_msg);
 
 use Pod::Usage   qw(pod2usage);
 use Getopt::Long qw(GetOptions);

--- a/po4a-updatepo
+++ b/po4a-updatepo
@@ -191,7 +191,7 @@ use Locale::Po4a::Po;
 
 use Locale::Po4a::Chooser;
 use Locale::Po4a::TransTractor;
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(wrap_msg);
 
 use Pod::Usage qw(pod2usage);
 

--- a/po4a-updatepo
+++ b/po4a-updatepo
@@ -191,7 +191,7 @@ use Locale::Po4a::Po;
 
 use Locale::Po4a::Chooser;
 use Locale::Po4a::TransTractor;
-use Locale::Po4a::Common qw(wrap_msg);
+use Locale::Po4a::Common qw(wrap_msg gettext);
 
 use Pod::Usage qw(pod2usage);
 

--- a/scripts/msgsearch
+++ b/scripts/msgsearch
@@ -140,7 +140,7 @@ use warnings;
 use Getopt::Long qw(GetOptions);
 
 use Locale::Po4a::Po;
-use Locale::Po4a::Common;
+use Locale::Po4a::Common qw(gettext);
 
 use Pod::Usage qw(pod2usage);
 

--- a/scripts/msgsearch
+++ b/scripts/msgsearch
@@ -144,7 +144,7 @@ use Locale::Po4a::Common;
 
 use Pod::Usage qw(pod2usage);
 
-textdomain('po4a');
+Locale::Po4a::Common::textdomain('po4a');
 
 sub show_version {
     Locale::Po4a::Common::show_version("msgsearch");


### PR DESCRIPTION
This is a continuation from #533.

According to the [Exporter's perldoc](https://perldoc.perl.org/Exporter), this change follows the rationales:

* Do as little exporting as possible.
* If exporting is necessary, use `@EXPORT_OK`.
  * Except for Testhelper; It sounds natural to align with [Test::More](https://metacpan.org/dist/Test-Simple/source/lib/Test/More.pm#L24).
* And make sure that the relationships (and inheritance) between modules are clear.

Commits are grouped as follows.

* Common module
* Po module
* TransTractor module
* Each format modules (from ancestor to descendant)

Followings are not the targets of this pull request:

- Remove `@AUTOLOAD` variable declarations
- Remove unused `makespace` subroutine declarations
- Use `our` for the version variable

Thank you,

- - -

TODO list:

- [x] Use `@EXPORT_OK` instead of `@EXPORT` in the Xml module, or remove it and use explicit calling
- [x] Tidy commits (improve message, merge some of them, and etc.)
- [x] Maybe split into several pull requests
- [x] Check each commits again
