### PR TITLE
man: fix po4a's incorrect handling of \& in doblequotes

### DIFF
--- a/lib/Locale/Po4a/Man.pm
+++ b/lib/Locale/Po4a/Man.pm
@@ -1674,25 +1674,25 @@ sub splitargs {
     # anymore. Let's play safe.
     $arguments =~ s/\\ /$nbs/g;
     $arguments =~ s/^ +//;
-    $arguments =~ s/\\&"/\\(dq/g;
     $arguments =~ s/^ *//;
     while ( length $arguments ) {
+        my $a;
         if ( $arguments =~ s/^"((?:[^"]|"")*)"(?!") *// ) {
-            my $a = $1;
+            $a = $1;
             $a =~ s/""/"/g if defined $a;
-            push @args, $a;
         } elsif ( $arguments =~ s/^"((?:[^"]|"")*) *$// ) {
 
             # Unterminated quote, but this seems to be handled by removing
             # the trailing spaces and closing the quotes.
-            my $a = $1;
+            $a = $1;
             $a =~ s/""/"/g if defined $a;
-            push @args, $a;
         } elsif ( $arguments =~ s/^([^ ]+) *// ) {
-            push @args, $1;
+            $a = $1;
         } else {
             die wrap_ref_mod( $ref, "po4a::man", dgettext( "po4a", "Cannot parse command arguments: %s" ), $arguments );
         }
+        $a =~ s/\\&"/\\(dq/g if (defined $a);
+        push @args, $a;
     }
     if ( $debug{'splitargs'} ) {
         print STDERR "ARGS=";

--- a/t/fmt/man/quotes.man
+++ b/t/fmt/man/quotes.man
@@ -33,3 +33,5 @@ should be equivalent to:
 
 .BI "-help"""a "-h"a "-?"a "/?"
 
+.\" Some shinenigans with \&, see https://github.com/mquinson/po4a/issues/445
+.BI "[\& ]\&"   \&"text\&"   "[\& \&"" ]\&"   "[\& \&"" ]\&

--- a/t/fmt/man/quotes.norm
+++ b/t/fmt/man/quotes.norm
@@ -37,3 +37,5 @@ should be equivalent to:
 
 \fB\-help"\fP\fIa\fP\fB\-h\fP\fIa\fP\fB\-?\fP\fIa\fP\fB/?\fP
 
+.\" Some shinenigans with \&, see https://github.com/mquinson/po4a/issues/445
+\fB[\& ]\&\fP\fI"text"\fP\fB[\& " ]\&\fP\fI[\& " ]\&\fP

--- a/t/fmt/man/quotes.po
+++ b/t/fmt/man/quotes.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-04-26 22:14+0200\n"
+"POT-Creation-Date: 2024-11-12 14:36+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -83,3 +83,9 @@ msgstr "THIS ALSO:"
 #: quotes.man:31 quotes.man:35
 msgid "B<-help\">I<a>B<-h>I<a>B<-?>I<a>B</?>"
 msgstr "B<-HELP\">I<1>B<-h>I<1>B<-?>I<1>B</?>"
+
+#.  Some shinenigans with \&, see https://github.com/mquinson/po4a/issues/445
+#. type: Plain text
+#: quotes.man:37
+msgid "B<[\\& ]\\&>I<\"text\">B<[\\& \" ]\\&>I<[\\& \" ]\\&>"
+msgstr "B<[\\& ]\\&>I<\"TEXT\">B<[\\& \" ]\\&>I<[\\& \" ]\\&>"

--- a/t/fmt/man/quotes.pot
+++ b/t/fmt/man/quotes.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-04-26 22:14+0200\n"
+"POT-Creation-Date: 2024-11-12 14:36+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -82,4 +82,10 @@ msgstr ""
 #. type: Plain text
 #: quotes.man:31 quotes.man:35
 msgid "B<-help\">I<a>B<-h>I<a>B<-?>I<a>B</?>"
+msgstr ""
+
+#.  Some shinenigans with \&, see https://github.com/mquinson/po4a/issues/445
+#. type: Plain text
+#: quotes.man:37
+msgid "B<[\\& ]\\&>I<\"text\">B<[\\& \" ]\\&>I<[\\& \" ]\\&>"
 msgstr ""

--- a/t/fmt/man/quotes.trans
+++ b/t/fmt/man/quotes.trans
@@ -37,3 +37,5 @@ SHOULD BE EQUIVALENT TO:
 
 \fB\-HELP"\fP\fI1\fP\fB\-h\fP\fI1\fP\fB\-?\fP\fI1\fP\fB/?\fP
 
+.\" Some shinenigans with \&, see https://github.com/mquinson/po4a/issues/445
+\fB[\& ]\&\fP\fI"TEXT"\fP\fB[\& " ]\&\fP\fI[\& " ]\&\fP


### PR DESCRIPTION
Namely do `s/\\&"/\\(dq/` only until after we handle all the quotes that might separate commands' arguments.

Closes: https://github.com/mquinson/po4a/issues/445