### PR TITLE
po4a-translate: remove --porefs option from docs

### DIFF
--- a/po4a-translate
+++ b/po4a-translate
@@ -112,20 +112,6 @@ Increase the verbosity of the program.
 
 Output some debugging information.
 
-=item B<--porefs> I<type>[,B<wrap>|B<nowrap>]
-
-Specify the reference format. Argument I<type> can be one of B<never>
-to not produce any reference, B<file> to only specify the file
-without the line number, B<counter> to replace line number by an
-increasing counter, and B<full> to include complete references (default: full).
-
-Argument can be followed by a comma and either B<wrap> or B<nowrap> keyword.
-References are written by default on a single line.  The B<wrap> option wraps
-references on several lines, to mimic B<gettext> tools (B<xgettext> and
-B<msgmerge>).  This option will become the default in a future release, because
-it is more sensible.  The B<nowrap> option is available so that users who want
-to keep the old behavior can do so.
-
 =back
 
 =head1 Adding content (beside translations) to generated files


### PR DESCRIPTION
As po4a-translate doesn't have such an option.