### PR TITLE
Fix test helper to exclude `--width` option from `po4a-updatepo` options

### DIFF
--- a/t/Testhelper.pm
+++ b/t/Testhelper.pm
@@ -476,8 +476,9 @@ sub run_one_format {
     unless ($error or exists $test->{'skip'}{'updatepo'}) {
         # Update PO
         copy( "$cwd/$pofile", "$cwd/${tmpbase}.po_updated" ) || fail "Cannot copy $pofile before updating it";
+        my $updatepo_options = $options =~ s/--width= [-]? [0-9]+//rxms;
         my $cmd =
-            "${execpath}/po4a-updatepo --no-deprecation -f $format $options "
+            "${execpath}/po4a-updatepo --no-deprecation -f $format $updatepo_options "
           . "--master $basename.$ext --po $cwd/${tmpbase}.po_updated"
           . " > $cwd/tmp/$path/update.stderr 2>&1";
 


### PR DESCRIPTION
This pull request addresses an issue with the test helper by ensuring that the options for `po4a-updatepo` do not include the `--width=<width>` option. This change may be related to commit faa7bc81720e7c3c5427d0bbde8c14998dd62934. 