### PR TITLE
Publish test container images

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,40 +1,61 @@
+---
 # This workflow will build po4a on linux using Module::Build
 name: Build on Linux CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - '*'
-    tags-ignore:
+    tags:
       - '*'
   pull_request:
+    branches:
+      - '**'
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Install Debian dependencies
-      run: |
-        sudo apt update 
-        sudo apt install -y liblocale-gettext-perl libtext-wrapi18n-perl libunicode-linebreak-perl libpod-parser-perl libtest-pod-perl libyaml-tiny-perl libsyntax-keyword-try-perl
-        sudo apt install -y cpanminus gettext docbook-xml docbook-xsl docbook xsltproc 
-        sudo apt install -y texlive-binaries texlive-latex-base opensp libsgmls-perl
-    - name: Install CPAN dependencies
-      run: |
-        cpanm Locale::gettext
-        cpanm http://search.cpan.org/CPAN/authors/id/R/RA/RAAB/SGMLSpm-1.1.tar.gz
-        cpanm Text::WrapI18N
-        cpanm Unicode::GCString
+    - uses: actions/checkout@v4
 
-        cpanm -v --installdeps --notest .
+    - name: Log in to the Container registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build
-      run: |
-        perl Build.PL
-        COLUMNS=120 ./Build verbose=1
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-    - name: Test
-      run: ./Build test verbose=1
+    - name: Build and push Docker image
+      id: push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: Containerfile
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+
+    - name: Generate artifact attestation
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        subject-digest: ${{ steps.push.outputs.digest }}
+        push-to-registry: true

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:latest
+
+ENV COLUMNS 120
+
+COPY . /srv/po4a
+WORKDIR /srv/po4a
+
+# Install Debian dependencies
+RUN apt update
+RUN apt install -y liblocale-gettext-perl libtext-wrapi18n-perl libunicode-linebreak-perl libpod-parser-perl libtest-pod-perl libyaml-tiny-perl libsyntax-keyword-try-perl
+RUN apt install -y cpanminus gettext docbook-xml docbook-xsl docbook xsltproc
+RUN apt install -y texlive-binaries texlive-latex-base opensp libsgmls-perl
+
+# Install CPAN dependencies
+RUN cpanm Locale::gettext
+RUN cpanm http://search.cpan.org/CPAN/authors/id/R/RA/RAAB/SGMLSpm-1.1.tar.gz
+RUN cpanm Text::WrapI18N
+RUN cpanm Unicode::GCString
+RUN cpanm -v --installdeps --notest .
+
+# Build
+RUN perl Build.PL
+RUN ./Build verbose=1
+
+# Test
+RUN adduser --disabled-password --gecos 'User for tests' nonroot
+RUN mkdir -p tmp
+# t/00-perms.t rejects tests running as root but then wants to change permisison inside t/
+RUN chown -R nonroot: t tmp
+USER nonroot
+RUN ./Build test verbose=1
+USER root
+
+# Install
+RUN ./Build install
+


### PR DESCRIPTION
Can be used to test po4a during development or when released.

The main motivation here is to simplify building the website since it requires built sources. This way website updates could be automated instead of the current manual process and then published via OpenShift.

The website deployment (aside from building and publishing the content) is done via Ansibel by RH OSPO and here is the corresponding change to switch to OpenShift: https://gitlab.com/osci/community-cage-infra-ansible/-/merge_requests/717

This requires a change in a role to deploy PHP on Openshift: https://gitlab.com/osci/ansible-role-openshift-apps/-/merge_requests/43
This role cannot use a lightweight web server in this case because the way Apache handles language file extensions (*.php.<lang>) in the original website could not be replicated (attempt with Caddy).

The `exit 1` in `01-build-pages.sh` when some language is unsupported for the footer was disabled to skip the error and be able to generate the rest. I'm not sure how this was done since the manual procedure is not ducumented and that may need to be revisited or the script updated.

The current draft bits are made using the image published in my PR branch and do not have webhooks as this requires access to this project I do not have but these will be changed later is accepted. We should be able to add webhooks for both the website change and the po4a sources changes.

Moreover the `01-build-pages.sh` script could be adapted to use po4a installed in PATH. The standard installation does this in /usr/local and this path could be added to PATH. That would allow to ship smaller images with /srv/po4a removed since most people would not need this.