### PR TITLE
Enhance DocBook document-to-manpage conversion process

### DIFF
--- a/.tidyallrc
+++ b/.tidyallrc
@@ -4,3 +4,4 @@ select = lib/**/*.pm
 select = t/*.{t,pm}
 select = *.pm
 argv = -utf8 -log -noll --maximum-line-length=120 --iterations=2 --cuddled-else
+select = Build.PL

--- a/Build.PL
+++ b/Build.PL
@@ -8,40 +8,47 @@
 use lib q(.);
 use Po4aBuilder;
 
-my $build = Po4aBuilder->new
-  ( module_name => 'po4a',
-      license => 'gpl',
-      dist_version_from => 'lib/Locale/Po4a/TransTractor.pm', # finds $VERSION
-      requires => { 'Pod::Parser' => 0 },   # Used for building po4a itself
-      configure_requires => { 'Module::Build' => 0.42 },
-      recommends => {'Text::WrapI18N' => 0, # Only used for wrapping long
-                                            # error/wraning lines.
+my $build = Po4aBuilder->new(
+    module_name        => 'po4a',
+    license            => 'gpl',
+    dist_version_from  => 'lib/Locale/Po4a/TransTractor.pm',    # finds $VERSION
+    requires           => { 'Pod::Parser' => 0 },               # Used for building po4a itself
+    configure_requires => { 'Module::Build' => 0.42 },
+    recommends         => {
+        'Text::WrapI18N' => 0,                                  # Only used for wrapping long
+                                                                # error/wraning lines.
 
-                     'Term::ReadKey' => 0,  # Needed to detect terminal
-                                            # width. Not needed if you
-                                            # don't have Text::WrapI18N.
+        'Term::ReadKey' => 0,                                   # Needed to detect terminal
+                                                                # width. Not needed if you
+                                                                # don't have Text::WrapI18N.
 
-                     'SGMLS' => 0,          # Needed for the Sgml module.
+        'SGMLS' => 0,                                           # Needed for the Sgml module.
 
-                     'Unicode::GCString' => 0, # Used by the AsciiDoc and VimHelp modules
+        'Unicode::GCString' => 0,                               # Used by the AsciiDoc and VimHelp modules
 
-                     'Locale::gettext' => '1.01', # Only used for
-                                                  # translating the
-                                                  # po4a's messages.
-	             'YAML::Tiny' => 0, # Used by the Yaml module
-                    },
-      test_requires => {'SGMLS' => 0,             # Needed for the Sgml module.
-                        'Unicode::GCString' => 0, # Used by the Text module (asciidoc)
-                       },
-      script_files => ['po4a-gettextize', 'po4a-updatepo',
-          'po4a-translate', 'po4a-normalize', 'po4a', 'msguntypot',
-          'scripts/po4a-display-man', 'scripts/po4a-display-pod'],
-      add_to_cleanup => ['t/tmp','po/bin/*.gmo', 'blib', '_build'],
-      dist_abstract => 'Maintain the translations of your documentation with ease (PO for anything)',
-      dist_author => ['Martin Quinson (mquinson#debian.org)',
-          'Denis Barbier <barbier@linuxfr.org>',
-          'Nicolas François <nicolas.francois@centraliens.net>',
-          'Neil Williams <linux@codehelp.co.uk>']
-  );
+        'Locale::gettext' => '1.01',                            # Only used for
+                                                                # translating the
+                                                                # po4a's messages.
+        'YAML::Tiny'      => 0,                                 # Used by the Yaml module
+    },
+    test_requires => {
+        'SGMLS'             => 0,                               # Needed for the Sgml module.
+        'Unicode::GCString' => 0,                               # Used by the Text module (asciidoc)
+    },
+    script_files => [
+        'po4a-gettextize',          'po4a-updatepo',
+        'po4a-translate',           'po4a-normalize',
+        'po4a',                     'msguntypot',
+        'scripts/po4a-display-man', 'scripts/po4a-display-pod'
+    ],
+    add_to_cleanup => [ 't/tmp', 'po/bin/*.gmo', 'blib', '_build' ],
+    dist_abstract  => 'Maintain the translations of your documentation with ease (PO for anything)',
+    dist_author    => [
+        'Martin Quinson (mquinson#debian.org)',
+        'Denis Barbier <barbier@linuxfr.org>',
+        'Nicolas François <nicolas.francois@centraliens.net>',
+        'Neil Williams <linux@codehelp.co.uk>'
+    ]
+);
 
 $build->create_build_script;

--- a/Build.PL
+++ b/Build.PL
@@ -9,31 +9,37 @@ use lib q(.);
 use Po4aBuilder;
 
 my $build = Po4aBuilder->new(
-    module_name        => 'po4a',
-    license            => 'gpl',
-    dist_version_from  => 'lib/Locale/Po4a/TransTractor.pm',    # finds $VERSION
-    requires           => { 'Pod::Parser' => 0 },               # Used for building po4a itself
+    module_name       => 'po4a',
+    license           => 'gpl',
+    dist_version_from => 'lib/Locale/Po4a/TransTractor.pm',    # finds $VERSION
+
+    # Used for building po4a itself.
+    requires => {
+        'Pod::Parser' => 0,
+        'IPC::Open3'  => 0,
+    },
+
     configure_requires => { 'Module::Build' => 0.42 },
     recommends         => {
-        'Text::WrapI18N' => 0,                                  # Only used for wrapping long
-                                                                # error/wraning lines.
+        'Text::WrapI18N' => 0,                                 # Only used for wrapping long
+                                                               # error/wraning lines.
 
-        'Term::ReadKey' => 0,                                   # Needed to detect terminal
-                                                                # width. Not needed if you
-                                                                # don't have Text::WrapI18N.
+        'Term::ReadKey' => 0,                                  # Needed to detect terminal
+                                                               # width. Not needed if you
+                                                               # don't have Text::WrapI18N.
 
-        'SGMLS' => 0,                                           # Needed for the Sgml module.
+        'SGMLS' => 0,                                          # Needed for the Sgml module.
 
-        'Unicode::GCString' => 0,                               # Used by the AsciiDoc and VimHelp modules
+        'Unicode::GCString' => 0,                              # Used by the AsciiDoc and VimHelp modules
 
-        'Locale::gettext' => '1.01',                            # Only used for
-                                                                # translating the
-                                                                # po4a's messages.
-        'YAML::Tiny'      => 0,                                 # Used by the Yaml module
+        'Locale::gettext' => '1.01',                           # Only used for
+                                                               # translating the
+                                                               # po4a's messages.
+        'YAML::Tiny'      => 0,                                # Used by the Yaml module
     },
     test_requires => {
-        'SGMLS'             => 0,                               # Needed for the Sgml module.
-        'Unicode::GCString' => 0,                               # Used by the Text module (asciidoc)
+        'SGMLS'             => 0,                              # Needed for the Sgml module.
+        'Unicode::GCString' => 0,                              # Used by the Text module (asciidoc)
     },
     script_files => [
         'po4a-gettextize',          'po4a-updatepo',

--- a/Containerfile
+++ b/Containerfile
@@ -5,10 +5,11 @@ ENV COLUMNS 120
 COPY . /srv/po4a
 WORKDIR /srv/po4a
 
-# Install Debian dependencies
+# Install Debian dependencies.
+# The libxml2-utils package provides the xmlcatalog program.
 RUN apt update
 RUN apt install -y liblocale-gettext-perl libtext-wrapi18n-perl libunicode-linebreak-perl libpod-parser-perl libtest-pod-perl libyaml-tiny-perl libsyntax-keyword-try-perl
-RUN apt install -y cpanminus gettext docbook-xml docbook-xsl docbook xsltproc
+RUN apt install -y cpanminus gettext docbook-xml docbook-xsl docbook xsltproc libxml2-utils
 RUN apt install -y texlive-binaries texlive-latex-base opensp libsgmls-perl
 
 # Install CPAN dependencies

--- a/Po4aBuilder.pm
+++ b/Po4aBuilder.pm
@@ -253,8 +253,14 @@ sub ACTION_man {
         foreach my $file (qw(po4a-display-man.xml po4a-display-pod.xml)) {
             copy( File::Spec->catdir( "share", "doc", $file ), $man1path ) or die;
         }
-        my $docbook_xsl_url   = "http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl";
-        my $local_docbook_xsl = `xmlcatalog --noout "" "$docbook_xsl_url"` =~ m,file://(.+\.xsl), && $1;
+
+        my $docbook_xsl_url = "http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl";
+        my $local_docbook_xsl;
+
+        # There appear to be two file path formats:
+        # "file:///path/to/XSLT/file" and "file:/path/to/XSLT/file".
+        `xmlcatalog --noout "" "$docbook_xsl_url"` =~ m,file:(?://)?(.+\.xsl), and $local_docbook_xsl = $1;
+
         foreach my $file ( @{ $self->rscan_dir( $manpath, qr{\.xml$} ) } ) {
             if ( $file =~ m,(.*/man(.))/([^/]*)\.xml$, ) {
                 my ( $outdir, $section, $outfile ) = ( $1, $2, $3 );


### PR DESCRIPTION
Hello,

This update introduces two minor improvements to the DocBook document-to-manpage conversion process:

1. Expanded file path detection to include the `file:/path/to/XSLT/file` format alongside the existing `file:///path/to/XSLT/file` format (e.g. `file:/gnu/store/.../manpages/docbook.xsl` with GNU Guix).
2. Utilization of the `IPC::Open3` module for invoking the `xmlcatalog` command, ensuring a more secure method for retrieving the XSLT file path in Perl scripts.

Thank you.