### PR TITLE
Remove textwidth option of VimHelp module

### DIFF
--- a/t/fmt/vimhelp/basic.norm.stderr
+++ b/t/fmt/vimhelp/basic.norm.stderr
@@ -1,4 +1,0 @@
-po4a::vimhelp: line#18 has columns 79 (> 78)
-po4a::vimhelp: line#19 has columns 79 (> 78)
-po4a::vimhelp: line#21 has columns 79 (> 78)
-po4a::vimhelp: line#22 has columns 79 (> 78)

--- a/t/fmt/vimhelp/basic.trans.stderr
+++ b/t/fmt/vimhelp/basic.trans.stderr
@@ -1,4 +1,0 @@
-po4a::vimhelp: line#18 has columns 79 (> 78)
-po4a::vimhelp: line#19 has columns 79 (> 78)
-po4a::vimhelp: line#21 has columns 79 (> 78)
-po4a::vimhelp: line#22 has columns 79 (> 78)


### PR DESCRIPTION
The `textwidth` option has been removed from the VimHelp module due to the complexity involved in achieving the desired behavior efficiently and effectively.  While initially intended to enhance functionality, its implementation presented challenges that made it impractical to retain under reasonable conditions.

Partially addresses #551.