### PR TITLE
Add support for Emacs bug-reference mode

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,33 @@
+;;; Emacs per-directory local variables.
+;;; Copyright © 2025 gemmaro <gemmaro.dev@gmail.com>
+;;;
+;;; This program is free software; you can redistribute it and/or modify it
+;;; under the terms of GPL v2.0 or later (see COPYING).
+
+;; Per-directory local variables for GNU Emacs 23 and later.
+((nil
+  . (;; For use with 'bug-reference-prog-mode'.
+
+     ;; 1. bug reference region
+     ;; 2. issue number
+     ;; 3. issue kind
+     ;;    - GitHub
+     (eval . (setq-local bug-reference-bug-regexp
+                         (rx (group
+                              (or
+                               (seq word-boundary (group-n 3 "GitHub") "'s #"
+                                    (group-n 2 (+ digit)))
+                               (seq word-boundary (group-n 3 "Debian") "'s #"
+                                    (group-n 2 (+ digit))))))))
+
+     (eval . (setq-local bug-reference-url-format
+                         (lambda ()
+                           (let ((num (match-string 2))
+                                 (kind (match-string 3)))
+                             (cond
+                              ((string= kind "GitHub")
+                               (concat "https://github.com/mquinson/po4a/pull/" num))
+                              ((string= kind "Debian")
+                               (concat
+                                "https://bugs.debian.org/cgi-bin/bugreport.cgi?bug="
+                                num))))))))))


### PR DESCRIPTION
This specifies a project-specific bug reference pattern and URL formats.
This allows bug tracker links to be highlightened, especially when the Emacs's bug-reference minor mode is enabled for the NEWS file, for instance.

Other project which has its own `.dir-locals.el` file: <https://git.savannah.gnu.org/cgit/guix.git/tree/.dir-locals.el>

![po4a-Emacs-bug-reference-NEWS](https://github.com/user-attachments/assets/6e9018db-910e-40ca-b3b4-22427c1bce49)
