### PR TITLE
Remove UTF-8 flag for PerlTidy in TidyAll config file.

### DIFF
--- a/.tidyallrc
+++ b/.tidyallrc
@@ -3,5 +3,5 @@ select = po4a{,-gettextize,-normalize,-translate,-updatepo}
 select = lib/**/*.pm
 select = t/*.{t,pm}
 select = *.pm
-argv = -utf8 -log -noll --maximum-line-length=120 --iterations=2 --cuddled-else
+argv = -log -noll --maximum-line-length=120 --iterations=2 --cuddled-else
 select = Build.PL


### PR DESCRIPTION
This might be specific to my environment, but removing this option seems to prevent garbled characters in files when running TidyAll.