### PR TITLE
Switch to SimplePod for po4a documents and fix reference handling

### DIFF
--- a/doc/addendum.ca
+++ b/doc/addendum.ca
@@ -1,4 +1,4 @@
-PO4A-HEADER:mode=after;position=^=head1 AUTORS;beginboundary=^=head1
+PO4A-HEADER:mode=after;position=\AAUTORS;beginboundary=^=head1
 
 =head1 TRADUCCIÓ
 

--- a/doc/addendum.es
+++ b/doc/addendum.es
@@ -1,4 +1,4 @@
-PO4A-HEADER:mode=after;position=^=head1 AUTORES;beginboundary=^=head1
+PO4A-HEADER:mode=after;position=\AAUTORES;beginboundary=^=head1
 
 =head1 TRADUCCION
 

--- a/doc/addendum.fr
+++ b/doc/addendum.fr
@@ -1,4 +1,4 @@
-PO4A-HEADER:mode=after;position=^=head1 AUTEURS;beginboundary=^=head1
+PO4A-HEADER:mode=after;position=\AAUTEURS;beginboundary=^=head1
 
 =head1 TRADUCTION
 

--- a/doc/addendum.it
+++ b/doc/addendum.it
@@ -1,4 +1,4 @@
-PO4A-HEADER:mode=after;position=^=head1 AUTORI;beginboundary=^=head1
+PO4A-HEADER:mode=after;position=\AAUTORI;beginboundary=^=head1
 
 =head1 TRADUZIONE
 

--- a/doc/addendum.ja
+++ b/doc/addendum.ja
@@ -1,4 +1,4 @@
-PO4A-HEADER:mode=after;position=^=head1 著者;beginboundary=^=head1
+PO4A-HEADER:mode=after;position=\A著者;beginboundary=^=head1
 
 =head1 訳者
 

--- a/doc/addendum.pl
+++ b/doc/addendum.pl
@@ -1,4 +1,4 @@
-PO4A-HEADER:mode=after;position=^=head1 AUTORZY;beginboundary=^=head1
+PO4A-HEADER:mode=after;position=\AAUTORZY;beginboundary=^=head1
 
 =head1 TŁUMACZENIE
 

--- a/doc/addendum.pt_BR
+++ b/doc/addendum.pt_BR
@@ -1,4 +1,4 @@
-PO4A-HEADER:mode=after;position=^=head1 AUTORES;beginboundary=^=head1
+PO4A-HEADER:mode=after;position=\AAUTORES;beginboundary=^=head1
 
 =head1 TRADUÇÃO
 

--- a/doc/addendum.zh_Hans
+++ b/doc/addendum.zh_Hans
@@ -1,4 +1,4 @@
-PO4A-HEADER:mode=after;position=^=head1 作者;beginboundary=^=head1
+PO4A-HEADER:mode=after;position=\A作者;beginboundary=^=head1
 
 =head1 翻译
 

--- a/lib/Locale/Po4a/SimplePod.pm
+++ b/lib/Locale/Po4a/SimplePod.pm
@@ -16,12 +16,15 @@ sub initialize {
 
 sub read {
     my ( $self, $filename, $refname, $charset ) = @_;
-    push @{ $self->{inputs} }, $filename;
+    push @{ $self->{inputs} }, { file => $filename, ref => $refname };
 }
 
 sub parse {
     my $self = shift;
-    $self->{parser}->parse_file($_) for @{ $self->{inputs} };
+    for my $input ( @{ $self->{inputs} } ) {
+        $self->{parser}->{current_ref} = $input->{ref};
+        $self->{parser}->parse_file( $input->{file} );
+    }
 }
 
 # We cannot use =begin since parsing this file with POD parser might cause

--- a/lib/Locale/Po4a/SimplePod/Parser.pm
+++ b/lib/Locale/Po4a/SimplePod/Parser.pm
@@ -208,7 +208,7 @@ sub _handle_element_end {
 
 sub translate_block {
     my ( $self, $line, $type, $wrap ) = @_;
-    my $ref = "$self->{source_filename}:$line";
+    my $ref = "$self->{current_ref}:$line";
     my $text = $self->{tractor}->translate( $self->{text}, $ref, $type, wrap => $wrap );
     undef $self->{text};
     return $text;

--- a/po/pod.cfg
+++ b/po/pod.cfg
@@ -1,7 +1,7 @@
 [po_directory] po/pod
 
 [po4a_alias:docbook] docbook opt:"-M UTF-8 -L UTF-8"
-[po4a_alias:pod] pod opt:"-M UTF-8 -L UTF-8"
+[po4a_alias:pod] simplepod opt:"-M UTF-8 -L UTF-8"
 [po4a_alias:man] man opt:"-M UTF-8 -L UTF-8"
 
 [options] opt:"--porefs=counter"


### PR DESCRIPTION
This is a continuation of #573 with the following updates:

- Fixes `ref` values in PO files to use proper `refname`s instead of full file paths.
- Switches our po4a processing POD manuals to use the SimplePod module.
- Updates addendum files accordingly.
