### PR TITLE
Po4aBuilder: remove redundant 'use strict'

### DIFF
--- a/Po4aBuilder.pm
+++ b/Po4aBuilder.pm
@@ -5,8 +5,7 @@
 
 package Po4aBuilder;
 
-use 5.16.0;
-use strict;
+use v5.16.0;
 use warnings;
 
 use parent qw(Module::Build);


### PR DESCRIPTION
`use strict` is redundant after `use v5.16.0` (`use`ing any perl version after 5.12 automatically enables strict: https://perldoc.perl.org/perl5120delta#Implicit-strictures).

Also, explicitly spell v-strings with a leading `v` because while `use 5.16.0`, `use v5.16.0`, and `use v5.16` will all do what you want, `use 5.16` will require version 5.160 of perl. So I generally prefer the belt-and-suspenders approach of specifying both `v` and a 3-part number.