### PR TITLE
Pass --wrap-po option counterparts to gettext utils

### DIFF
--- a/lib/Locale/Po4a/Po.pm
+++ b/lib/Locale/Po4a/Po.pm
@@ -103,7 +103,7 @@ use strict;
 use warnings;
 
 use parent qw(Exporter);
-our @EXPORT_OK = qw(move_po_if_needed);
+our @EXPORT_OK = qw(move_po_if_needed gettext_wrap_opts);
 
 use IO::File;
 
@@ -1424,6 +1424,33 @@ sub get_charset() {
         return $1;
     } else {
         return "UTF-8";
+    }
+}
+
+=item gettext_wrap_opts($)
+
+A small utility function that returns a string with appropriate
+C<--no-wrap>/C<--width> gettext utilities' options coresponding to the given
+B<wrap-po> value.
+
+=cut
+
+sub gettext_wrap_opts($) {
+    my $wrap_po = shift;
+    if ( ! defined $wrap_po or ! length $wrap_po ) {
+        return "";
+    } elsif ( $wrap_po eq 'no' or $wrap_po eq 'newlines' ) {
+        # Note: gettext will always wrap on newlines, so there is no difference between the two
+        return "--no-wrap";
+    } elsif( $wrap_po =~ /^[+-]?\d+$/ ) {
+        return "--width=$wrap_po";
+    } else {
+        warn wrap_mod( "po4a::po",
+            dgettext( "po4a",
+                "Invalid value for option 'wrap-po' ('%s' is not 'no' nor 'newlines' nor a number)"),
+            $wrap_po
+        );
+        return "";
     }
 }
 

--- a/po4a
+++ b/po4a
@@ -339,6 +339,12 @@ content. If set to B<newlines>, po4a will only split the msgid and msgstr after
 newlines in the content. If set to B<no>, po4a will not wrap the po file at all.
 The reference comments are always wrapped by the gettext tools that we use internally.
 
+Based on the value of this option appropriate flags (B<--no-wrap> or
+B<--width>=I<number>) will be passed to underlying gettext tutilities.
+Unfortunately getext doesn't prowide any counterpart for B<--wrap-po> I<no>, so
+in that case B<--no-wrap> will be passed (the same as for B<--wrap-po>
+I<newlines>).
+
 Note that this option has no impact on how the msgid and msgstr are wrapped, i.e.
 on how newlines are added to the content of these strings.
 
@@ -712,7 +718,7 @@ use Getopt::Long qw(GetOptions);
 use Locale::Po4a::Chooser;
 use Locale::Po4a::TransTractor;
 use Locale::Po4a::Common qw(wrap_msg wrap_ref_mod gettext dgettext);
-use Locale::Po4a::Po qw(move_po_if_needed);
+use Locale::Po4a::Po qw(move_po_if_needed gettext_wrap_opts);
 
 use Pod::Usage qw(pod2usage);
 
@@ -1070,7 +1076,6 @@ sub check_target_langs {
     }
     return $line;
 }
-
 
 # The document hash table contains all the information about the files to translate.
 # Each key of the hash map a master file, ie a file to translate. For each such master file, we have a sub-hashmap containing:
@@ -1766,7 +1771,9 @@ if ( $po4a_opts{"split"} ) {
                 mkdir $dir or die wrap_msg( gettext("Cannot create directory '%s': %s"), $dir, $! );
             }
             my $outfile = $po4a_opts{"force"} ? find_output_file($master_pot) : $tmp_file;
-            my $cmd     = "msggrep$Config{_exe} $split_pot_files{$master_pot} -o $outfile $pot_filename --force-po";
+            my $cmd     = "msggrep$Config{_exe} $split_pot_files{$master_pot}"
+                        . " " . gettext_wrap_opts($po4a_opts{"wrap-po"})
+                        . " -o $outfile $pot_filename --force-po";
             run_cmd($cmd);
 
             die wrap_msg(
@@ -1809,7 +1816,8 @@ if ( $po4a_opts{"split"} ) {
             $split_po{$lang}{$master} = $master_po;
         }
         if ( length $cmd_cat ) {
-            $cmd_cat = "msgcat" . $Config{_exe} . " -o $tmp_bigpo $cmd_cat";
+            $cmd_cat = "msgcat" . $Config{_exe} . gettext_wrap_opts($po4a_opts{"wrap-po"})
+                . " -o $tmp_bigpo $cmd_cat";
             run_cmd($cmd_cat);
         }
 
@@ -1845,7 +1853,8 @@ if ( not $po4a_opts{"no-update"} ) {
             if ($usable_pofile) {
                 my $msgmerge_opt = $po4a_opts{"msgmerge-opt"};
                 $msgmerge_opt =~ s/\$lang\b/$lang/g if scalar @langs;
-                my $cmd = "msgmerge" . $Config{_exe} . " \"$infile\" \"$updated_potfile\" " . $msgmerge_opt;
+                my $cmd = "msgmerge" . $Config{_exe} . " \"$infile\" \"$updated_potfile\" " . $msgmerge_opt
+                    . " " . gettext_wrap_opts($po4a_opts{"wrap-po"});
                 if ( $infile eq $outfile ) {           # in place
                     $cmd .= " --backup=none --update";
                 } else {
@@ -1875,8 +1884,9 @@ if ( not $po4a_opts{"no-update"} ) {
                 }
 
                 my $read_pot_filename = find_input_file($pot_filename);
-                my $cmd =
-                  "msginit$Config{_exe} -i \"$read_pot_filename\" --locale $lang -o \"$outfile\" --no-translator >$devnull";
+                my $cmd = "msginit$Config{_exe} -i \"$read_pot_filename\" --locale $lang"
+                        . " " . gettext_wrap_opts($po4a_opts{"wrap-po"})
+                        . " -o \"$outfile\" --no-translator >$devnull";
                 run_cmd($cmd);
             }
         }
@@ -1911,13 +1921,15 @@ if ( not $po4a_opts{"no-update"} ) {
                             $env
                           . " msggrep$Config{_exe}"
                           . " --force-po --invert-match --msgid --regexp '.'"
+                          . " " . gettext_wrap_opts($po4a_opts{"wrap-po"})
                           . " --output \"$tmp_file\" "
                           . find_input_file( $split_po{$lang}{$master} );
                     } else {
                         $cmd =
                             "msginit$Config{_exe} "
-                          . "--no-translator -l $lang --input " . '"'
-                          . find_output_file( $split_pot{$master} ) . '"'
+                          . "--no-translator -l $lang"
+                          . " " . gettext_wrap_opts($po4a_opts{"wrap-po"})
+                          . " --input " . '"' . find_output_file( $split_pot{$master} ) . '"'
                           . " --output $tmp_file  >$devnull";
                     }
                     run_cmd($cmd);
@@ -1929,6 +1941,7 @@ if ( not $po4a_opts{"no-update"} ) {
                       . $po_filename{$lang} . '"'
                       . " --update --backup=none "
                       . $po4a_opts{"msgmerge-opt"}
+                      . " " . gettext_wrap_opts($po4a_opts{"wrap-po"})
                       . " \"$tmp_file\" " . '"'
                       . find_output_file( $split_pot{$master} ) . '"';
                     run_cmd($cmd);

--- a/po4a-updatepo
+++ b/po4a-updatepo
@@ -130,6 +130,12 @@ content. If set to B<newlines>, po4a will only split the msgid and msgstr after
 newlines in the content. If set to B<no>, po4a will not wrap the po file at all.
 The wrapping of the reference comments is controlled by the B<--porefs> option.
 
+Based on the value of this option appropriate flags (B<--no-wrap> or
+B<--width>=I<number>) will be passed to underlying gettext tutilities.
+Unfortunately getext doesn't prowide any counterpart for B<--wrap-po> I<no>, so
+in that case B<--no-wrap> will be passed (the same as for B<--wrap-po>
+I<newlines>).
+
 Note that this option has no impact on how the msgid and msgstr are wrapped, i.e.
 on how newlines are added to the content of these strings.
 
@@ -249,6 +255,7 @@ pod2usage() if scalar @masterfiles < 1 || scalar @pofiles < 1;
 
 $msgmerge_opt .= " --previous" unless $noprevious;
 $msgmerge_opt .= " --add-location=file" if ( $porefs =~ m/^file/ );
+$msgmerge_opt .= " " . Locale::Po4a::Po::gettext_wrap_opts($wrappo) if ( $wrappo );
 $msgmerge_opt =~ s/^\s+//;
 
 my %options = (

--- a/t/cfg-args.t
+++ b/t/cfg-args.t
@@ -87,6 +87,18 @@ push @tests, {
     'options'          => '--no-update --target-lang=de --target-lang=fr',
     'expected_outfile' => '_output-target-lang',
     'expected_files'   => 'man.de.1 man.fr.1'
+  },
+  {
+    'doc'              => '--wrap-po 60',
+    'po4a.conf'        => 'cfg/args-wrap-po/po4a.conf',
+    'options'          => '--wrap-po 60',
+    'expected_files'   => 'args-wrap-po.pot args-wrap-po.en.po args-wrap-po.fr.po man.en.1'
+  },
+  {
+    'doc'              => '--wrap-po newlines',
+    'po4a.conf'        => 'cfg/args-wrap-po-newlines/po4a.conf',
+    'options'          => '--wrap-po newlines',
+    'expected_files'   => 'args-wrap-po.pot args-wrap-po.en.po args-wrap-po.fr.po man.en.1'
   };
 
 run_all_tests(@tests);

--- a/t/cfg/args-wrap-po-newlines/_args-wrap-po.en.po
+++ b/t/cfg/args-wrap-po-newlines/_args-wrap-po.en.po
@@ -1,0 +1,66 @@
+# English translations for po package
+# Copyright (C) 2025 Free Software Foundation, Inc.
+# This file is distributed under the same license as the po package.
+# Automatically generated, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: po 4a\n"
+"POT-Creation-Date: 2025-07-19 07:46+0300\n"
+"PO-Revision-Date: 2025-07-19 03:00+0300\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. type: TH
+#: man.1:1
+#, no-wrap
+msgid "test1"
+msgstr "TEST1"
+
+#. type: SH
+#: man.1:2
+#, no-wrap
+msgid "NAME"
+msgstr "name"
+
+#. type: Plain text
+#: man.1:4
+msgid "test - just a test"
+msgstr "TEST - JUST A TEST"
+
+#. type: Plain text
+#: man.1:6
+msgid "This paragraph ends at column 59. bla! bla! bla! bla! bla!"
+msgstr "THIS TRANSLATION ENDS AT COLUMN 60. BLA! BLA! BLA! BLA!!!!!"
+
+#. type: Plain text
+#: man.1:8
+msgid "This paragraph ends at column 60. bla! bla! bla! bla! bla!!"
+msgstr "THIS TRANSLATION ENDS AT COLUMN 59. BLA! BLA! BLA! BLA!!!!"
+
+#. type: Plain text
+#: man.1:11
+msgid "This paragraph is over 80 characters long! This paragraph is over 80 characters long!"
+msgstr ""
+"THIS PARAGRAPH IS OVER 80 CHARACTERS LONG! THIS PARAGRAPH IS OVER 80 CHARACTERS LONG!\n"
+"AND A TRANSLATOR ADDED AN EXTRA LINEBREAK. BLA! BLA! BLA! BLA! BLA! BLA! BLA! BLA! BLA! BLA! BLA!"
+
+#. type: Plain text
+#: man.1:15
+#, no-wrap
+msgid ""
+"This verbatim paragraph is wrapped at 80 characters! Note that verbatim -------\n"
+"paragraphs shouldn't get rewrapped inside POs.\n"
+msgstr ""
+"THIS VERBATIM PARAGRAPH IS WRAPPED AT 80 CHARACTERS! nOTE THAT VERBATIM -------\n"
+"PARAGRAPHS SHOULDN'T GET REWRAPPED INSIDE POS.\n"
+
+#. type: Plain text
+#: man.1:17
+msgid "This is a new line that will trigger update of PO files."
+msgstr ""

--- a/t/cfg/args-wrap-po-newlines/_args-wrap-po.fr.po
+++ b/t/cfg/args-wrap-po-newlines/_args-wrap-po.fr.po
@@ -1,0 +1,62 @@
+# French translations for po package
+# Copyright (C) 2025 Free Software Foundation, Inc.
+# This file is distributed under the same license as the po package.
+# Automatically generated, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: po 4a\n"
+"POT-Creation-Date: 2025-07-19 07:46+0300\n"
+"PO-Revision-Date: 2025-07-19 07:46+0300\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. type: TH
+#: man.1:1
+#, no-wrap
+msgid "test1"
+msgstr ""
+
+#. type: SH
+#: man.1:2
+#, no-wrap
+msgid "NAME"
+msgstr ""
+
+#. type: Plain text
+#: man.1:4
+msgid "test - just a test"
+msgstr ""
+
+#. type: Plain text
+#: man.1:6
+msgid "This paragraph ends at column 59. bla! bla! bla! bla! bla!"
+msgstr ""
+
+#. type: Plain text
+#: man.1:8
+msgid "This paragraph ends at column 60. bla! bla! bla! bla! bla!!"
+msgstr ""
+
+#. type: Plain text
+#: man.1:11
+msgid "This paragraph is over 80 characters long! This paragraph is over 80 characters long!"
+msgstr ""
+
+#. type: Plain text
+#: man.1:15
+#, no-wrap
+msgid ""
+"This verbatim paragraph is wrapped at 80 characters! Note that verbatim -------\n"
+"paragraphs shouldn't get rewrapped inside POs.\n"
+msgstr ""
+
+#. type: Plain text
+#: man.1:17
+msgid "This is a new line that will trigger update of PO files."
+msgstr ""

--- a/t/cfg/args-wrap-po-newlines/_args-wrap-po.pot
+++ b/t/cfg/args-wrap-po-newlines/_args-wrap-po.pot
@@ -1,0 +1,62 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2025-07-19 06:42+0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: TH
+#: man.1:1
+#, no-wrap
+msgid "test1"
+msgstr ""
+
+#. type: SH
+#: man.1:2
+#, no-wrap
+msgid "NAME"
+msgstr ""
+
+#. type: Plain text
+#: man.1:4
+msgid "test - just a test"
+msgstr ""
+
+#. type: Plain text
+#: man.1:6
+msgid "This paragraph ends at column 59. bla! bla! bla! bla! bla!"
+msgstr ""
+
+#. type: Plain text
+#: man.1:8
+msgid "This paragraph ends at column 60. bla! bla! bla! bla! bla!!"
+msgstr ""
+
+#. type: Plain text
+#: man.1:11
+msgid "This paragraph is over 80 characters long! This paragraph is over 80 characters long!"
+msgstr ""
+
+#. type: Plain text
+#: man.1:15
+#, no-wrap
+msgid ""
+"This verbatim paragraph is wrapped at 80 characters! Note that verbatim -------\n"
+"paragraphs shouldn't get rewrapped inside POs.\n"
+msgstr ""
+
+#. type: Plain text
+#: man.1:17
+msgid "This is a new line that will trigger update of PO files."
+msgstr ""

--- a/t/cfg/args-wrap-po-newlines/_output
+++ b/t/cfg/args-wrap-po-newlines/_output
@@ -1,0 +1,5 @@
+Updating args-wrap-po.pot: (8 entries)
+Updating args-wrap-po.en.po: 7 translated messages, 1 untranslated message.
+Creating an empty PO file in args-wrap-po.fr.po.
+man.en.1 is 87.5% translated (7 of 8 strings).
+Discard man.fr.1 (0 of 8 strings; only 0% translated; need 80%).

--- a/t/cfg/args-wrap-po-newlines/args-wrap-po.en.po
+++ b/t/cfg/args-wrap-po-newlines/args-wrap-po.en.po
@@ -1,0 +1,71 @@
+# English translations for po package
+# Copyright (C) 2025 Free Software Foundation, Inc.
+# This file is distributed under the same license as the po package.
+# Automatically generated, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: po 4a\n"
+"POT-Creation-Date: 2025-07-19 06:42+0300\n"
+"PO-Revision-Date: 2025-07-19 03:00+0300\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. type: TH
+#: man.1:1
+#, no-wrap
+msgid "test1"
+msgstr "TEST1"
+
+#. type: SH
+#: man.1:2
+#, no-wrap
+msgid "NAME"
+msgstr "name"
+
+#. type: Plain text
+#: man.1:4
+msgid "test - just a test"
+msgstr "TEST - JUST A TEST"
+
+#. type: Plain text
+#: man.1:6
+msgid ""
+"This paragraph ends at column 59. bla! bla! bla! bla! bla!"
+msgstr ""
+"THIS TRANSLATION ENDS AT COLUMN 60. BLA! BLA! BLA! "
+"BLA!!!!!"
+
+#. type: Plain text
+#: man.1:8
+msgid ""
+"This paragraph ends at column 60. bla! bla! bla! bla! "
+"bla!!"
+msgstr ""
+"THIS TRANSLATION ENDS AT COLUMN 59. BLA! BLA! BLA! BLA!!!!"
+
+#. type: Plain text
+#: man.1:11
+msgid ""
+"This paragraph is over 80 characters long! This paragraph "
+"is over 80 characters long!"
+msgstr ""
+"THIS PARAGRAPH IS OVER 80 CHARACTERS LONG! THIS PARAGRAPH "
+"IS OVER 80 CHARACTERS LONG!\n"
+"AND A TRANSLATOR ADDED AN EXTRA LINEBREAK. BLA! BLA! BLA! "
+"BLA! BLA! BLA! BLA! BLA! BLA! BLA! BLA!"
+
+#. type: Plain text
+#: man.1:15
+#, no-wrap
+msgid ""
+"This verbatim paragraph is wrapped at 80 characters! Note that verbatim -------\n"
+"paragraphs shouldn't get rewrapped inside POs.\n"
+msgstr ""
+"THIS VERBATIM PARAGRAPH IS WRAPPED AT 80 CHARACTERS! nOTE THAT VERBATIM -------\n"
+"PARAGRAPHS SHOULDN'T GET REWRAPPED INSIDE POS.\n"

--- a/t/cfg/args-wrap-po-newlines/args-wrap-po.pot
+++ b/t/cfg/args-wrap-po-newlines/args-wrap-po.pot
@@ -1,0 +1,60 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2025-07-19 06:42+0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: TH
+#: man.1:1
+#, no-wrap
+msgid "test1"
+msgstr ""
+
+#. type: SH
+#: man.1:2
+#, no-wrap
+msgid "NAME"
+msgstr ""
+
+#. type: Plain text
+#: man.1:4
+msgid "test - just a test"
+msgstr ""
+
+#. type: Plain text
+#: man.1:6
+msgid "This paragraph ends at column 59. bla! bla! bla! bla! bla!"
+msgstr ""
+
+#. type: Plain text
+#: man.1:8
+msgid "This paragraph ends at column 60. bla! bla! bla! bla! bla!!"
+msgstr ""
+
+#. type: Plain text
+#: man.1:11
+msgid ""
+"This paragraph is over 80 characters long! This paragraph is "
+"over 80 characters long!"
+msgstr ""
+
+#. type: Plain text
+#: man.1:15
+#, no-wrap
+msgid ""
+"This verbatim paragraph is wrapped at 80 characters! Note "
+"that verbatim -------\n"
+"paragraphs shouldn't get rewrapped inside POs.\n"
+msgstr ""

--- a/t/cfg/args-wrap-po-newlines/man.1
+++ b/t/cfg/args-wrap-po-newlines/man.1
@@ -1,0 +1,17 @@
+.TH test1 1
+.SH NAME
+test \- just a test
+
+This paragraph ends at column 59. bla! bla! bla! bla! bla!
+
+This paragraph ends at column 60. bla! bla! bla! bla! bla!!
+
+This paragraph is over 80 characters long! 
+This paragraph is over 80 characters long!
+
+.nf
+This verbatim paragraph is wrapped at 80 characters! Note that verbatim -------
+paragraphs shouldn't get rewrapped inside POs.
+.fi
+
+This is a new line that will trigger update of PO files.

--- a/t/cfg/args-wrap-po-newlines/man.en.1
+++ b/t/cfg/args-wrap-po-newlines/man.en.1
@@ -1,0 +1,24 @@
+.\"*******************************************************************
+.\"
+.\" This file was generated with po4a. Translate the source file.
+.\"
+.\"*******************************************************************
+.TH TEST1 1   
+.SH name
+TEST \- JUST A TEST
+
+THIS TRANSLATION ENDS AT COLUMN 60. BLA! BLA! BLA! BLA!!!!!
+
+THIS TRANSLATION ENDS AT COLUMN 59. BLA! BLA! BLA! BLA!!!!
+
+THIS PARAGRAPH IS OVER 80 CHARACTERS LONG! THIS PARAGRAPH IS OVER 80
+CHARACTERS LONG!
+AND A TRANSLATOR ADDED AN EXTRA LINEBREAK. BLA! BLA! BLA! BLA! BLA! BLA!
+BLA! BLA! BLA! BLA! BLA!
+
+.nf
+THIS VERBATIM PARAGRAPH IS WRAPPED AT 80 CHARACTERS! nOTE THAT VERBATIM \-\-\-\-\-\-\-
+PARAGRAPHS SHOULDN'T GET REWRAPPED INSIDE POS.
+.fi
+
+This is a new line that will trigger update of PO files.

--- a/t/cfg/args-wrap-po-newlines/po4a.conf
+++ b/t/cfg/args-wrap-po-newlines/po4a.conf
@@ -1,0 +1,4 @@
+[po4a_langs] en fr
+[po4a_paths] args-wrap-po.pot $lang:args-wrap-po.$lang.po
+
+[type:man] man.1 $lang:man.$lang.1

--- a/t/cfg/args-wrap-po/_args-wrap-po.en.po
+++ b/t/cfg/args-wrap-po/_args-wrap-po.en.po
@@ -1,0 +1,77 @@
+# English translations for po package
+# Copyright (C) 2025 Free Software Foundation, Inc.
+# This file is distributed under the same license as the po package.
+# Automatically generated, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: po 4a\n"
+"POT-Creation-Date: 2025-07-19 06:42+0300\n"
+"PO-Revision-Date: 2025-07-19 03:00+0300\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. type: TH
+#: man.1:1
+#, no-wrap
+msgid "test1"
+msgstr "TEST1"
+
+#. type: SH
+#: man.1:2
+#, no-wrap
+msgid "NAME"
+msgstr "name"
+
+#. type: Plain text
+#: man.1:4
+msgid "test - just a test"
+msgstr "TEST - JUST A TEST"
+
+#. type: Plain text
+#: man.1:6
+msgid ""
+"This paragraph ends at column 59. bla! bla! bla! bla! bla!"
+msgstr ""
+"THIS TRANSLATION ENDS AT COLUMN 60. BLA! BLA! BLA! "
+"BLA!!!!!"
+
+#. type: Plain text
+#: man.1:8
+msgid ""
+"This paragraph ends at column 60. bla! bla! bla! bla! "
+"bla!!"
+msgstr ""
+"THIS TRANSLATION ENDS AT COLUMN 59. BLA! BLA! BLA! BLA!!!!"
+
+#. type: Plain text
+#: man.1:11
+msgid ""
+"This paragraph is over 80 characters long! This paragraph "
+"is over 80 characters long!"
+msgstr ""
+"THIS PARAGRAPH IS OVER 80 CHARACTERS LONG! THIS PARAGRAPH "
+"IS OVER 80 CHARACTERS LONG!\n"
+"AND A TRANSLATOR ADDED AN EXTRA LINEBREAK. BLA! BLA! BLA! "
+"BLA! BLA! BLA! BLA! BLA! BLA! BLA! BLA!"
+
+#. type: Plain text
+#: man.1:15
+#, no-wrap
+msgid ""
+"This verbatim paragraph is wrapped at 80 characters! Note that verbatim -------\n"
+"paragraphs shouldn't get rewrapped inside POs.\n"
+msgstr ""
+"THIS VERBATIM PARAGRAPH IS WRAPPED AT 80 CHARACTERS! nOTE THAT VERBATIM -------\n"
+"PARAGRAPHS SHOULDN'T GET REWRAPPED INSIDE POS.\n"
+
+#. type: Plain text
+#: man.1:17
+msgid ""
+"This is a new line that will trigger update of PO files."
+msgstr ""

--- a/t/cfg/args-wrap-po/_args-wrap-po.fr.po
+++ b/t/cfg/args-wrap-po/_args-wrap-po.fr.po
@@ -1,0 +1,68 @@
+# French translations for po package
+# Copyright (C) 2025 Free Software Foundation, Inc.
+# This file is distributed under the same license as the po package.
+# Automatically generated, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: po 4a\n"
+"POT-Creation-Date: 2025-07-19 07:03+0300\n"
+"PO-Revision-Date: 2025-07-19 07:03+0300\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. type: TH
+#: man.1:1
+#, no-wrap
+msgid "test1"
+msgstr ""
+
+#. type: SH
+#: man.1:2
+#, no-wrap
+msgid "NAME"
+msgstr ""
+
+#. type: Plain text
+#: man.1:4
+msgid "test - just a test"
+msgstr ""
+
+#. type: Plain text
+#: man.1:6
+msgid ""
+"This paragraph ends at column 59. bla! bla! bla! bla! bla!"
+msgstr ""
+
+#. type: Plain text
+#: man.1:8
+msgid ""
+"This paragraph ends at column 60. bla! bla! bla! bla! "
+"bla!!"
+msgstr ""
+
+#. type: Plain text
+#: man.1:11
+msgid ""
+"This paragraph is over 80 characters long! This paragraph "
+"is over 80 characters long!"
+msgstr ""
+
+#. type: Plain text
+#: man.1:15
+#, no-wrap
+msgid ""
+"This verbatim paragraph is wrapped at 80 characters! Note that verbatim -------\n"
+"paragraphs shouldn't get rewrapped inside POs.\n"
+msgstr ""
+
+#. type: Plain text
+#: man.1:17
+msgid ""
+"This is a new line that will trigger update of PO files."
+msgstr ""

--- a/t/cfg/args-wrap-po/_args-wrap-po.pot
+++ b/t/cfg/args-wrap-po/_args-wrap-po.pot
@@ -1,0 +1,65 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2025-07-19 06:42+0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: TH
+#: man.1:1
+#, no-wrap
+msgid "test1"
+msgstr ""
+
+#. type: SH
+#: man.1:2
+#, no-wrap
+msgid "NAME"
+msgstr ""
+
+#. type: Plain text
+#: man.1:4
+msgid "test - just a test"
+msgstr ""
+
+#. type: Plain text
+#: man.1:6
+msgid "This paragraph ends at column 59. bla! bla! bla! bla! bla!"
+msgstr ""
+
+#. type: Plain text
+#: man.1:8
+msgid "This paragraph ends at column 60. bla! bla! bla! bla! bla!!"
+msgstr ""
+
+#. type: Plain text
+#: man.1:11
+msgid ""
+"This paragraph is over 80 characters long! This paragraph is "
+"over 80 characters long!"
+msgstr ""
+
+#. type: Plain text
+#: man.1:15
+#, no-wrap
+msgid ""
+"This verbatim paragraph is wrapped at 80 characters! Note "
+"that verbatim -------\n"
+"paragraphs shouldn't get rewrapped inside POs.\n"
+msgstr ""
+
+#. type: Plain text
+#: man.1:17
+msgid "This is a new line that will trigger update of PO files."
+msgstr ""

--- a/t/cfg/args-wrap-po/_output
+++ b/t/cfg/args-wrap-po/_output
@@ -1,0 +1,5 @@
+Updating args-wrap-po.pot: (8 entries)
+Updating args-wrap-po.en.po: 7 translated messages, 1 untranslated message.
+Creating an empty PO file in args-wrap-po.fr.po.
+man.en.1 is 87.5% translated (7 of 8 strings).
+Discard man.fr.1 (0 of 8 strings; only 0% translated; need 80%).

--- a/t/cfg/args-wrap-po/args-wrap-po.en.po
+++ b/t/cfg/args-wrap-po/args-wrap-po.en.po
@@ -1,0 +1,61 @@
+# English translations for po package
+# Copyright (C) 2025 Free Software Foundation, Inc.
+# This file is distributed under the same license as the po package.
+# Automatically generated, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: po 4a\n"
+"POT-Creation-Date: 2025-07-19 06:31+0300\n"
+"PO-Revision-Date: 2025-07-19 03:00+0300\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. type: TH
+#: man.1:1
+#, no-wrap
+msgid "test1"
+msgstr "TEST1"
+
+#. type: SH
+#: man.1:2
+#, no-wrap
+msgid "NAME"
+msgstr "name"
+
+#. type: Plain text
+#: man.1:4
+msgid "test - just a test"
+msgstr "TEST - JUST A TEST"
+
+#. type: Plain text
+#: man.1:6
+msgid "This paragraph ends at column 59. bla! bla! bla! bla! bla!"
+msgstr "THIS TRANSLATION ENDS AT COLUMN 60. BLA! BLA! BLA! BLA!!!!!"
+
+#. type: Plain text
+#: man.1:8
+msgid "This paragraph ends at column 60. bla! bla! bla! bla! bla!!"
+msgstr "THIS TRANSLATION ENDS AT COLUMN 59. BLA! BLA! BLA! BLA!!!!"
+
+#. type: Plain text
+#: man.1:11
+msgid "This paragraph is over 80 characters long! This paragraph is over 80 characters long!"
+msgstr ""
+"THIS PARAGRAPH IS OVER 80 CHARACTERS LONG! THIS PARAGRAPH IS OVER 80 CHARACTERS LONG!\n"
+"AND A TRANSLATOR ADDED AN EXTRA LINEBREAK. BLA! BLA! BLA! BLA! BLA! BLA! BLA! BLA! BLA! BLA! BLA!"
+
+#. type: Plain text
+#: man.1:15
+#, no-wrap
+msgid ""
+"This verbatim paragraph is wrapped at 80 characters! Note that verbatim -------\n"
+"paragraphs shouldn't get rewrapped inside POs.\n"
+msgstr ""
+"THIS VERBATIM PARAGRAPH IS WRAPPED AT 80 CHARACTERS! nOTE THAT VERBATIM -------\n"
+"PARAGRAPHS SHOULDN'T GET REWRAPPED INSIDE POS.\n"

--- a/t/cfg/args-wrap-po/args-wrap-po.pot
+++ b/t/cfg/args-wrap-po/args-wrap-po.pot
@@ -1,0 +1,57 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2025-07-19 06:31+0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: TH
+#: man.1:1
+#, no-wrap
+msgid "test1"
+msgstr ""
+
+#. type: SH
+#: man.1:2
+#, no-wrap
+msgid "NAME"
+msgstr ""
+
+#. type: Plain text
+#: man.1:4
+msgid "test - just a test"
+msgstr ""
+
+#. type: Plain text
+#: man.1:6
+msgid "This paragraph ends at column 59. bla! bla! bla! bla! bla!"
+msgstr ""
+
+#. type: Plain text
+#: man.1:8
+msgid "This paragraph ends at column 60. bla! bla! bla! bla! bla!!"
+msgstr ""
+
+#. type: Plain text
+#: man.1:11
+msgid "This paragraph is over 80 characters long! This paragraph is over 80 characters long!"
+msgstr ""
+
+#. type: Plain text
+#: man.1:15
+#, no-wrap
+msgid ""
+"This verbatim paragraph is wrapped at 80 characters! Note that verbatim -------\n"
+"paragraphs shouldn't get rewrapped inside POs.\n"
+msgstr ""

--- a/t/cfg/args-wrap-po/man.1
+++ b/t/cfg/args-wrap-po/man.1
@@ -1,0 +1,17 @@
+.TH test1 1
+.SH NAME
+test \- just a test
+
+This paragraph ends at column 59. bla! bla! bla! bla! bla!
+
+This paragraph ends at column 60. bla! bla! bla! bla! bla!!
+
+This paragraph is over 80 characters long! 
+This paragraph is over 80 characters long!
+
+.nf
+This verbatim paragraph is wrapped at 80 characters! Note that verbatim -------
+paragraphs shouldn't get rewrapped inside POs.
+.fi
+
+This is a new line that will trigger update of PO files.

--- a/t/cfg/args-wrap-po/man.en.1
+++ b/t/cfg/args-wrap-po/man.en.1
@@ -1,0 +1,24 @@
+.\"*******************************************************************
+.\"
+.\" This file was generated with po4a. Translate the source file.
+.\"
+.\"*******************************************************************
+.TH TEST1 1   
+.SH name
+TEST \- JUST A TEST
+
+THIS TRANSLATION ENDS AT COLUMN 60. BLA! BLA! BLA! BLA!!!!!
+
+THIS TRANSLATION ENDS AT COLUMN 59. BLA! BLA! BLA! BLA!!!!
+
+THIS PARAGRAPH IS OVER 80 CHARACTERS LONG! THIS PARAGRAPH IS OVER 80
+CHARACTERS LONG!
+AND A TRANSLATOR ADDED AN EXTRA LINEBREAK. BLA! BLA! BLA! BLA! BLA! BLA!
+BLA! BLA! BLA! BLA! BLA!
+
+.nf
+THIS VERBATIM PARAGRAPH IS WRAPPED AT 80 CHARACTERS! nOTE THAT VERBATIM \-\-\-\-\-\-\-
+PARAGRAPHS SHOULDN'T GET REWRAPPED INSIDE POS.
+.fi
+
+This is a new line that will trigger update of PO files.

--- a/t/cfg/args-wrap-po/po4a.conf
+++ b/t/cfg/args-wrap-po/po4a.conf
@@ -1,0 +1,4 @@
+[po4a_langs] en fr
+[po4a_paths] args-wrap-po.pot $lang:args-wrap-po.$lang.po
+
+[type:man] man.1 $lang:man.$lang.1


### PR DESCRIPTION
Pass appropriate `--width` or `--no-wrap` options in subsequent calls to msgmerge, msggrep, msgcat and mdginit according to `--wrap-po`.

Closes: https://github.com/mquinson/po4a/issues/574