### PR TITLE
Fix typos in the docs

### DIFF
--- a/lib/Locale/Po4a/Po.pm
+++ b/lib/Locale/Po4a/Po.pm
@@ -1430,7 +1430,7 @@ sub get_charset() {
 =item gettext_wrap_opts($)
 
 A small utility function that returns a string with appropriate
-C<--no-wrap>/C<--width> gettext utilities' options coresponding to the given
+C<--no-wrap>/C<--width> gettext utilities' options corresponding to the given
 B<wrap-po> value.
 
 =cut

--- a/po4a
+++ b/po4a
@@ -341,7 +341,7 @@ The reference comments are always wrapped by the gettext tools that we use inter
 
 Based on the value of this option, appropriate flags (B<--no-wrap> or
 B<--width>=I<number>) will be passed to underlying gettext utilities.
-Unfortunately gettext doesn't prowide any counterpart for B<--wrap-po> I<no>, so
+Unfortunately gettext doesn't provide any counterpart for B<--wrap-po> I<no>, so
 in that case B<--no-wrap> will be passed (the same as for B<--wrap-po>
 I<newlines>).
 

--- a/po4a
+++ b/po4a
@@ -339,9 +339,9 @@ content. If set to B<newlines>, po4a will only split the msgid and msgstr after
 newlines in the content. If set to B<no>, po4a will not wrap the po file at all.
 The reference comments are always wrapped by the gettext tools that we use internally.
 
-Based on the value of this option appropriate flags (B<--no-wrap> or
-B<--width>=I<number>) will be passed to underlying gettext tutilities.
-Unfortunately getext doesn't prowide any counterpart for B<--wrap-po> I<no>, so
+Based on the value of this option, appropriate flags (B<--no-wrap> or
+B<--width>=I<number>) will be passed to underlying gettext utilities.
+Unfortunately gettext doesn't prowide any counterpart for B<--wrap-po> I<no>, so
 in that case B<--no-wrap> will be passed (the same as for B<--wrap-po>
 I<newlines>).
 

--- a/po4a-updatepo
+++ b/po4a-updatepo
@@ -130,9 +130,9 @@ content. If set to B<newlines>, po4a will only split the msgid and msgstr after
 newlines in the content. If set to B<no>, po4a will not wrap the po file at all.
 The wrapping of the reference comments is controlled by the B<--porefs> option.
 
-Based on the value of this option appropriate flags (B<--no-wrap> or
-B<--width>=I<number>) will be passed to underlying gettext tutilities.
-Unfortunately getext doesn't prowide any counterpart for B<--wrap-po> I<no>, so
+Based on the value of this option, appropriate flags (B<--no-wrap> or
+B<--width>=I<number>) will be passed to underlying gettext utilities.
+Unfortunately gettext doesn't prowide any counterpart for B<--wrap-po> I<no>, so
 in that case B<--no-wrap> will be passed (the same as for B<--wrap-po>
 I<newlines>).
 

--- a/po4a-updatepo
+++ b/po4a-updatepo
@@ -132,7 +132,7 @@ The wrapping of the reference comments is controlled by the B<--porefs> option.
 
 Based on the value of this option, appropriate flags (B<--no-wrap> or
 B<--width>=I<number>) will be passed to underlying gettext utilities.
-Unfortunately gettext doesn't prowide any counterpart for B<--wrap-po> I<no>, so
+Unfortunately gettext doesn't provide any counterpart for B<--wrap-po> I<no>, so
 in that case B<--no-wrap> will be passed (the same as for B<--wrap-po>
 I<newlines>).
 


### PR DESCRIPTION
Some typos found when translating po4a-doc. Please let me know if using the squash option in the merge button ia not an option.