### PR TITLE
Avoid implicit perl imports - make them explicit.

### DIFF
--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -28,7 +28,7 @@ use warnings;
 use parent qw(Locale::Po4a::TransTractor);
 
 use Locale::Po4a::Common qw(wrap_mod dgettext);
-use YAML::Tiny;
+use YAML::Tiny qw();
 
 =head1 OPTIONS ACCEPTED BY THIS MODULE
 


### PR DESCRIPTION
See:

https://perl-begin.org/tutorials/bad-elements/#non_explicitly_imported_symbols .