### PR TITLE
Minor refactoring: Use File::Spec for /dev/null path

### DIFF
--- a/Po4aBuilder.pm
+++ b/Po4aBuilder.pm
@@ -240,9 +240,10 @@ sub ACTION_man {
             $command = "msggrep -K -E -e \"Po4a Tools\" po/pod/$lang.po |";
             $command .= "msgconv -t UTF-8 | ";
             $command .= "msgexec /bin/sh -c '[ -n \"\$MSGEXEC_MSGID\" ] ";
-            $command .= "&& cat || cat > /dev/null'";
+            my $devnull = File::Spec->devnull;
+            $command .= "&& cat || cat > $devnull'";
 
-            my $title = `$command 2> /dev/null`;
+            my $title = `$command 2> $devnull`;
             $title             = "Po4a Tools" unless length $title;
             $title             = Encode::decode_utf8($title);
             $parser->{release} = $parser->{center} = $title;
@@ -313,8 +314,9 @@ sub postats {
     my ( @t100, @t95, @t90, @t80, @t70, @t50, @t33, @t20, @starting );
 
     foreach my $file ( sort @files ) {
-        my $lang = fileparse( $file, qw{.po} );
-        my $stat = `msgfmt -o /dev/null -c --statistics $file 2>&1`;
+        my $lang    = fileparse( $file, qw{.po} );
+        my $devnull = File::Spec->devnull;
+        my $stat    = `msgfmt -o $devnull -c --statistics $file 2>&1`;
         my ( $trans, $fuzz, $untr ) = ( 0, 0, 0 );
         if ( $stat =~ /(\d+)\D+?(\d+)\D+?(\d+)/ ) {
             ( $trans, $fuzz, $untr ) = ( $1, $2, $3 );

--- a/lib/Locale/Po4a/Po.pm
+++ b/lib/Locale/Po4a/Po.pm
@@ -115,7 +115,8 @@ use Carp qw(croak);
 use File::Basename;
 use File::Path;    # mkdir before write
 use File::Copy;    # move
-use POSIX qw(strftime floor);
+use File::Spec qw();
+use POSIX      qw(strftime floor);
 use Time::Local;
 
 use Encode;
@@ -322,7 +323,8 @@ sub read {
     $self->{lang} = $lang;
 
     if ($checkvalidity) {   # We sometimes need to read a file even if it may be invalid (eg to test whether it's empty)
-        my $cmd = "msgfmt" . $Config{_exe} . " --check-format --check-domain -o /dev/null \"" . $filename . '"';
+        my $devnull = File::Spec->devnull;
+        my $cmd     = "msgfmt" . $Config{_exe} . " --check-format --check-domain -o $devnull \"" . $filename . '"';
 
         my $locale = $ENV{'LC_ALL'};
         $ENV{'LC_ALL'} = "C";

--- a/lib/Locale/Po4a/Sgml.pm
+++ b/lib/Locale/Po4a/Sgml.pm
@@ -212,6 +212,8 @@ use warnings;
 
 use parent qw(Locale::Po4a::TransTractor);
 
+use File::Spec qw();
+
 use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod dgettext);
 
 eval qq{use SGMLS};
@@ -861,7 +863,8 @@ sub parse_file {
     print $tmpfh $origfile;
     close $tmpfh or die wrap_mod( "po4a::sgml", dgettext( "po4a", "Cannot close tempfile: %s" ), $! );
 
-    my $cmd = "onsgmls -l -E 0 -wno-valid $tmpfile" . ( $debug{'onsgmls'} ? "" : " 2>/dev/null" ) . " |";
+    my $devnull = File::Spec->devnull;
+    my $cmd     = "onsgmls -l -E 0 -wno-valid $tmpfile" . ( $debug{'onsgmls'} ? "" : " 2>$devnull" ) . " |";
     print STDERR "CMD=$cmd\n" if ( $debug{'generic'} or $debug{'onsgmls'} );
 
     open( IN, $cmd ) || die wrap_mod( "po4a::sgml", dgettext( "po4a", "Cannot run onsgmls: %s" ), $! );

--- a/po4a
+++ b/po4a
@@ -845,8 +845,7 @@ sub show_version {
 # keep the command line arguments
 my @ORIGINAL_ARGV = @ARGV;
 
-# Use /NUL instead of /dev/null on Windows
-my $devnull = ( $^O =~ /Win/ ) ? '/NUL' : '/dev/null';
+my $devnull = File::Spec->devnull;
 
 # Parse the options provided on the command line, or in argument
 sub get_options {


### PR DESCRIPTION
This change replaces hardcoded `/dev/null` paths with `File::Spec->devnull`. This is a non-functional change that enhances OS independence without altering behavior.
