### PR TITLE
Minor refactoring: simpify debug/verbose option handling

### DIFF
--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -214,7 +214,6 @@ sub initialize {
 
     $self->{options}{'nobullets'}      = 1;
     $self->{options}{'forcewrap'}      = 0;
-    $self->{options}{'debug'}          = '';
     $self->{options}{'entry'}          = '';
     $self->{options}{'macro'}          = '';
     $self->{options}{'style'}          = '';
@@ -240,8 +239,8 @@ sub initialize {
         $compat, 'asciidoc', 'asciidoctor' )
       if ( defined $compat && $compat ne "asciidoc" && $compat ne "asciidoctor" );
 
-    if ( $options{'debug'} ) {
-        foreach ( $options{'debug'} ) {
+    if ( $self->{options}{debug} ) {
+        foreach ( $self->{options}{debug} ) {
             $debug{$_} = 1;
         }
     }

--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -1021,7 +1021,7 @@ sub parse {
             $line = "";
             undef $self->{bullet};
             undef $self->{indent};
-        } elsif ( (not defined($self->{verbatim})) and ($line =~ /^\|={3,}$/) ) {
+        } elsif ( ( not defined( $self->{verbatim} ) ) and ( $line =~ /^\|={3,}$/ ) ) {
 
             # This is a table, treat it as a non-wrapped paragraph
             print STDERR "Found Table delimiter\n" if ( $debug{parse} );

--- a/lib/Locale/Po4a/AsciiDoc.pm
+++ b/lib/Locale/Po4a/AsciiDoc.pm
@@ -215,7 +215,6 @@ sub initialize {
     $self->{options}{'nobullets'}      = 1;
     $self->{options}{'forcewrap'}      = 0;
     $self->{options}{'debug'}          = '';
-    $self->{options}{'verbose'}        = 1;
     $self->{options}{'entry'}          = '';
     $self->{options}{'macro'}          = '';
     $self->{options}{'style'}          = '';

--- a/lib/Locale/Po4a/Dia.pm
+++ b/lib/Locale/Po4a/Dia.pm
@@ -94,7 +94,7 @@ sub initialize {
     $self->SUPER::initialize(%options);
     $self->{options}{'nostrip'} = 1;
     $self->{options}{'_default_translated'} .= ' <dia:string>';
-    print "Call treat_options\n" if $self->{options}{'debug'};
+    print "Call treat_options\n" if $self->debug;
     $self->treat_options;
 }
 

--- a/lib/Locale/Po4a/Docbook.pm
+++ b/lib/Locale/Po4a/Docbook.pm
@@ -2052,8 +2052,7 @@ sub initialize {
         lang
         xml:lang';
 
-    print "Call treat_options\n"
-      if $self->{options}{'debug'};
+    print "Call treat_options\n" if $self->debug;
     $self->treat_options;
 }
 

--- a/lib/Locale/Po4a/Guide.pm
+++ b/lib/Locale/Po4a/Guide.pm
@@ -146,7 +146,7 @@ sub initialize {
         <sup>
         <uri>
         <var>';
-    print "Call treat_options\n" if $self->{options}{'debug'};
+    print "Call treat_options\n" if $self->debug;
     $self->treat_options;
 }
 

--- a/lib/Locale/Po4a/InProgress/Debconf.pm
+++ b/lib/Locale/Po4a/InProgress/Debconf.pm
@@ -184,7 +184,7 @@ sub parse {
 
             $bit =~ s/\s*$//;
 
-            $extended .= ( $verb        ? "\n" : ' ' ) if length $extended && $extended !~ /[\n ]$/;
+            $extended .= ( $verb ? "\n" : ' ' ) if length $extended && $extended !~ /[\n ]$/;
             $extended .= $bit . ( $verb ? "\n" : "" );
 
             # this may be an empty line closing the stanza, a comment or even a parse error (if file not DebConf-clean).

--- a/lib/Locale/Po4a/InProgress/Debconf.pm
+++ b/lib/Locale/Po4a/InProgress/Debconf.pm
@@ -118,9 +118,9 @@ sub parse {
             }
 
             $eval .= ")\n";
-            print STDERR $eval if $self->{options}{'debug'};
+            print STDERR $eval if $self->debug;
             eval $eval;
-            print STDERR "XXXXXXXXXXXXXXXXX\n" if $self->{options}{'debug'};
+            print STDERR "XXXXXXXXXXXXXXXXX\n" if $self->debug;
 
             # two leading _: split on coma and multi-translate each part. No extended value.
         } elsif ( $undercount == 2 ) {
@@ -140,7 +140,7 @@ sub parse {
             }
             $eval .= ")\n";
 
-            print $eval if $self->{options}{'debug'};
+            print $eval if $self->debug;
             eval $eval;
 
             # no leading _: don't touch it

--- a/lib/Locale/Po4a/InProgress/NewsDebian.pm
+++ b/lib/Locale/Po4a/InProgress/NewsDebian.pm
@@ -74,7 +74,7 @@ sub parse {
 
     # main loop
     ( $line, $lref ) = $self->shiftline();
-    print "seen >>$line<<\n" if $self->{options}{'debug'};
+    print "seen >>$line<<\n" if $self->debug;
     while ( defined($line) ) {
 
         # Begining of an entry
@@ -93,7 +93,7 @@ sub parse {
             # eat all leading empty lines
             ( $line, $lref ) = $self->shiftline();
             while ( defined($line) && $line =~ m/^\s*$/ ) {
-                print "Eat >>$line<<\n" if $self->{options}{'debug'};
+                print "Eat >>$line<<\n" if $self->debug;
                 ( $line, $lref ) = $self->shiftline();
             }
 
@@ -122,7 +122,7 @@ sub parse {
         }
 
         ( $line, $lref ) = $self->shiftline();
-        print "seen >>" . ( $line || '' ) . "<<\n" if $self->{options}{'debug'};
+        print "seen >>" . ( $line || '' ) . "<<\n" if $self->debug;
     }
 }
 

--- a/lib/Locale/Po4a/Ini.pm
+++ b/lib/Locale/Po4a/Ini.pm
@@ -20,8 +20,6 @@ use Locale::Po4a::Common;
 
 use vars qw($AUTOLOAD);
 
-my $debug = 0;
-
 sub parse {
     my $self = shift;
     my ( $line, $ref );
@@ -32,25 +30,25 @@ sub parse {
 
     while ( defined($line) ) {
         chomp($line);
-        print STDERR "begin\n" if $debug;
+        print STDERR "begin\n" if $self->debug;
 
         if ( $line =~ /\"/ ) {
-            print STDERR "Start of line containing \".\n" if $debug;
+            print STDERR "Start of line containing \".\n" if $self->debug;
 
             # Text before the first quote
             $line =~ m/(^[^"\r\n]*)"/;
             my $pre_text = $1;
-            print STDERR "  PreText=" . $pre_text . "\n" if $debug;
+            print STDERR "  PreText=" . $pre_text . "\n" if $self->debug;
 
             # The text for translation
             $line =~ m/"([^\r\n]*)"/;
             my $quoted_text = $1;
-            print STDERR "  QuotedText=" . $quoted_text . "\n" if $debug;
+            print STDERR "  QuotedText=" . $quoted_text . "\n" if $self->debug;
 
             # Text after last quote
             $line =~ m/"([^"\n]*$)/;
             my $post_text = $1;
-            print STDERR "  PostText=" . $post_text . "\n" if $debug;
+            print STDERR "  PostText=" . $post_text . "\n" if $self->debug;
 
             # Translate the string it
             $par = $self->translate( $quoted_text, $ref, $pre_text );
@@ -60,9 +58,9 @@ sub parse {
 
             # Now push the result
             $self->pushline( $pre_text . '"' . $par . '"' . $post_text . "\n" );
-            print STDERR "End of line containing \".\n" if $debug;
+            print STDERR "End of line containing \".\n" if $self->debug;
         } else {
-            print STDERR "Other stuff\n" if $debug;
+            print STDERR "Other stuff\n" if $self->debug;
             $self->pushline("$line\n");
         }
 

--- a/lib/Locale/Po4a/KernelHelp.pm
+++ b/lib/Locale/Po4a/KernelHelp.pm
@@ -22,8 +22,6 @@ use Locale::Po4a::Common qw(wrap_ref_mod gettext);
 
 use vars qw($AUTOLOAD);
 
-my $debug = 0;
-
 sub parse {
     my $self = shift;
     my ( $line, $ref );
@@ -40,22 +38,22 @@ sub parse {
 
     while ( defined($line) ) {
         chomp($line);
-        print STDERR "status=$status;Seen >>$line<<:" if $debug;
+        print STDERR "status=$status;Seen >>$line<<:" if $self->debug;
 
         if ( $line =~ /^\#/ ) {
-            print STDERR "comment.\n" if $debug;
+            print STDERR "comment.\n" if $self->debug;
             $self->pushline("$line\n");
         } elsif ( $status == 0 ) {
             if ( $line =~ /\S/ ) {
-                print STDERR "short desc.\n" if $debug;
+                print STDERR "short desc.\n" if $self->debug;
                 $desc = $line;
                 $status++;
             } else {
-                print STDERR "empty line.\n" if $debug;
+                print STDERR "empty line.\n" if $self->debug;
                 $self->pushline("$line\n");
             }
         } elsif ( $status == 1 ) {
-            print STDERR "var name.\n" if $debug;
+            print STDERR "var name.\n" if $self->debug;
             $variable = $line;
             $status++;
 
@@ -64,10 +62,10 @@ sub parse {
         } elsif ( $status == 2 ) {
             $line =~ s/^  //;
             if ( $line =~ /\S/ ) {
-                print STDERR "paragraph line.\n" if $debug;
+                print STDERR "paragraph line.\n" if $self->debug;
                 $paragraph .= $line . "\n";
             } else {
-                print STDERR "end of paragraph.\n" if $debug;
+                print STDERR "end of paragraph.\n" if $self->debug;
                 $status++;
                 $paragraph = $self->translate( $paragraph, $ref, "helptxt_$variable" );
                 $paragraph =~ s/^/  /gm;
@@ -77,11 +75,11 @@ sub parse {
         } elsif ( $status == 3 ) {
             if ( $line =~ s/^  // ) {
                 if ( $line =~ /\S/ ) {
-                    print "begin of paragraph.\n" if $debug;
+                    print "begin of paragraph.\n" if $self->debug;
                     $paragraph = $line . "\n";
                     $status--;
                 } else {
-                    print "end of config option.\n" if $debug;
+                    print "end of config option.\n" if $self->debug;
                     $status = 0;
                     $self->pushline("\n");
                 }

--- a/lib/Locale/Po4a/KernelHelp.pm
+++ b/lib/Locale/Po4a/KernelHelp.pm
@@ -27,11 +27,11 @@ my $debug = 0;
 sub parse {
     my $self = shift;
     my ( $line, $ref );
-    my $paragraph = "";                     # Buffer where we put the paragraph while building
-    my ($status)  = 0;                      # Syntax of KH is:
-                                            #   description<nl>variable<nl>help text<nl><nl>
-                                            # Status will be:
-                                            #   0             1            2        3   0
+    my $paragraph = "";    # Buffer where we put the paragraph while building
+    my ($status)  = 0;     # Syntax of KH is:
+                           #   description<nl>variable<nl>help text<nl><nl>
+                           # Status will be:
+                           #   0             1            2        3   0
 
     my ( $desc, $variable );
 

--- a/lib/Locale/Po4a/Man.pm
+++ b/lib/Locale/Po4a/Man.pm
@@ -471,7 +471,6 @@ sub initialize {
     my %options = @_;
 
     $self->{options}{'debug'}            = '';
-    $self->{options}{'verbose'}          = '';
     $self->{options}{'groff_code'}       = '';
     $self->{options}{'untranslated'}     = '';
     $self->{options}{'noarg'}            = '';

--- a/lib/Locale/Po4a/Man.pm
+++ b/lib/Locale/Po4a/Man.pm
@@ -405,8 +405,8 @@ use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod dgettext);
 use File::Spec;
 use Getopt::Std;
 
-my %macro;                                             # hash of known macro, with parsing sub. See end of this file
-my %default_macro;                                     # The default known macros, when no options are used.
+my %macro;            # hash of known macro, with parsing sub. See end of this file
+my %default_macro;    # The default known macros, when no options are used.
 
 # A font start by \f and is followed either by
 # [.*] - a font name within brackets (e.g. [P], [A_USER_FONT])
@@ -968,9 +968,9 @@ sub pushmacro {
                         length($_)
                         ? ( m/([^\\] |^ )/ ? "\"$_\"" : "$_" )
 
-                          # Quote arguments that contain a space.
-                          # (not needed for non breaknig spaces, i.e.
-                          # spaces preceded by '\')
+                        # Quote arguments that contain a space.
+                        # (not needed for non breaknig spaces, i.e.
+                        # spaces preceded by '\')
                         : '""'    # empty argument
                       )
                       : ''        # no argument
@@ -1691,7 +1691,7 @@ sub splitargs {
         } else {
             die wrap_ref_mod( $ref, "po4a::man", dgettext( "po4a", "Cannot parse command arguments: %s" ), $arguments );
         }
-        $a =~ s/\\&"/\\(dq/g if (defined $a);
+        $a =~ s/\\&"/\\(dq/g if ( defined $a );
         push @args, $a;
     }
     if ( $debug{'splitargs'} ) {

--- a/lib/Locale/Po4a/Man.pm
+++ b/lib/Locale/Po4a/Man.pm
@@ -470,7 +470,6 @@ sub initialize {
     my $self    = shift;
     my %options = @_;
 
-    $self->{options}{'debug'}            = '';
     $self->{options}{'groff_code'}       = '';
     $self->{options}{'untranslated'}     = '';
     $self->{options}{'noarg'}            = '';
@@ -491,8 +490,8 @@ sub initialize {
     }
 
     %debug = ();
-    if ( defined $options{'debug'} ) {
-        foreach ( $options{'debug'} ) {
+    if ( $self->{options}{'debug'} ) {
+        foreach ( $self->{options}{'debug'} ) {
             $debug{$_} = 1;
         }
     }

--- a/lib/Locale/Po4a/Org.pm
+++ b/lib/Locale/Po4a/Org.pm
@@ -254,7 +254,7 @@ sub parse_plain_list {
             $self->pushline("$content\n");
         }
     } else {
-        my $ref = $self->parse_plain_list_following_paragraph( \@content, $margin );
+        my $ref     = $self->parse_plain_list_following_paragraph( \@content, $margin );
         my $content = $self->translate( join( "\n", @content ), $ref, "plain list $type" );
         $content =~ s/ ^ /$margin/mgxs;
         $content =~ s/ \A \Q$margin\E //xsm;
@@ -294,7 +294,7 @@ sub parse_table {
     if ( $cells =~ / \A [-+|]* \Z /xsm ) {
         $self->pushline("$line\n");
     } else {
-        my @cells = split / [ ]* [|] [ ]* /xsm, $cells;
+        my @cells   = split / [ ]* [|] [ ]* /xsm, $cells;
         my $content = join( ' | ', map { $self->translate( $cells[$_], $ref, "cell column $_" ) } ( 0 .. $#cells ) );
         $self->pushline("$prefix$content |\n");
     }
@@ -354,7 +354,7 @@ sub parse_paragraph {
 }
 
 sub handle_paragraph_if_any {
-    my ( $self ) = @_;
+    my ($self) = @_;
 
     $self->{paragraph} or return;
     my $type = 'paragraph';
@@ -372,9 +372,7 @@ sub handle_paragraph_if_any {
         }
     }
 
-    my $content = $self->translate( $self->{paragraph},
-                                    $self->{paragraph_ref},
-                                    $type, wrap => $wrap );
+    my $content = $self->translate( $self->{paragraph}, $self->{paragraph_ref}, $type, wrap => $wrap );
     $content =~ s/ ^ /$self->{paragraph_margin}/mgxs;
     $self->pushline("$content\n");
 

--- a/lib/Locale/Po4a/Org.pm
+++ b/lib/Locale/Po4a/Org.pm
@@ -38,7 +38,6 @@ sub initialize {
     $self->{options}{skip_properties} = [];
     $self->{options}{skip_heading}    = 0;
     $self->{options}{debug}           = 0;
-    $self->{options}{verbose}         = 0;
 
     foreach my $opt ( keys %options ) {
         exists $self->{options}{$opt}
@@ -47,7 +46,6 @@ sub initialize {
 
     $self->{options}{skip_heading} = $options{skip_heading};
     $self->{options}{debug}        = $options{debug};
-    $self->{options}{verbose}      = $options{verbose};
 
     foreach my $option_name ( 'skip_keywords', 'skip_properties' ) {
         my $option = $options{$option_name} or next;

--- a/lib/Locale/Po4a/Org.pm
+++ b/lib/Locale/Po4a/Org.pm
@@ -37,7 +37,6 @@ sub initialize {
     $self->{options}{skip_keywords}   = [];
     $self->{options}{skip_properties} = [];
     $self->{options}{skip_heading}    = 0;
-    $self->{options}{debug}           = 0;
 
     foreach my $opt ( keys %options ) {
         exists $self->{options}{$opt}
@@ -45,7 +44,6 @@ sub initialize {
     }
 
     $self->{options}{skip_heading} = $options{skip_heading};
-    $self->{options}{debug}        = $options{debug};
 
     foreach my $option_name ( 'skip_keywords', 'skip_properties' ) {
         my $option = $options{$option_name} or next;

--- a/lib/Locale/Po4a/RubyDoc.pm
+++ b/lib/Locale/Po4a/RubyDoc.pm
@@ -65,7 +65,6 @@ sub initialize {
     my %options = @_;
 
     $self->{options}{'debug'}   = 1;
-    $self->{options}{'verbose'} = 1;
     $self->{options}{'puredoc'} = 0;
 
     foreach my $opt ( keys %options ) {

--- a/lib/Locale/Po4a/RubyDoc.pm
+++ b/lib/Locale/Po4a/RubyDoc.pm
@@ -64,7 +64,6 @@ sub initialize {
     my $self    = shift;
     my %options = @_;
 
-    $self->{options}{'debug'}   = 1;
     $self->{options}{'puredoc'} = 0;
 
     foreach my $opt ( keys %options ) {

--- a/lib/Locale/Po4a/Sgml.pm
+++ b/lib/Locale/Po4a/Sgml.pm
@@ -255,8 +255,6 @@ sub initialize {
 
     $self->{options}{'force'} = '';
 
-    $self->{options}{'debug'} = '';
-
     foreach my $opt ( keys %options ) {
         if ( $options{$opt} ) {
             die wrap_mod( "po4a::sgml", dgettext( "po4a", "Unknown option: %s" ), $opt )
@@ -264,8 +262,8 @@ sub initialize {
             $self->{options}{$opt} = $options{$opt};
         }
     }
-    if ( $options{'debug'} ) {
-        foreach ( split /\s+/, $options{'debug'} ) {
+    if ( $self->{options}{'debug'} ) {
+        foreach ( split /\s+/, $self->{options}{'debug'} ) {
             die wrap_mod( "po4a::sgml", dgettext( "po4a", "Unknown debug category: %s. Known categories:\n%s" ),
                 $_, join( " ", keys %debug ) )
               unless exists $debug{$_};

--- a/lib/Locale/Po4a/Sgml.pm
+++ b/lib/Locale/Po4a/Sgml.pm
@@ -255,8 +255,7 @@ sub initialize {
 
     $self->{options}{'force'} = '';
 
-    $self->{options}{'verbose'} = '';
-    $self->{options}{'debug'}   = '';
+    $self->{options}{'debug'} = '';
 
     foreach my $opt ( keys %options ) {
         if ( $options{$opt} ) {

--- a/lib/Locale/Po4a/TeX.pm
+++ b/lib/Locale/Po4a/TeX.pm
@@ -1633,7 +1633,6 @@ sub initialize {
     $self->{options}{'no_wrap'}         = '';
     $self->{options}{'verbatim'}        = '';
     $self->{options}{'debug'}           = '';
-    $self->{options}{'verbose'}         = '';
     $self->{options}{'no-warn'}         = 0;    # TexInfo option to not warn about the state of the module
 
     %debug = ();

--- a/lib/Locale/Po4a/TeX.pm
+++ b/lib/Locale/Po4a/TeX.pm
@@ -65,8 +65,8 @@ use warnings;
 use parent qw(Locale::Po4a::TransTractor);
 
 use Locale::Po4a::Common qw(wrap_mod wrap_ref_mod dgettext);
-use File::Basename qw(dirname);
-use Carp           qw(croak);
+use File::Basename       qw(dirname);
+use Carp                 qw(croak);
 
 use Encode;
 use Encode::Guess;

--- a/lib/Locale/Po4a/TeX.pm
+++ b/lib/Locale/Po4a/TeX.pm
@@ -1632,7 +1632,6 @@ sub initialize {
     $self->{options}{'exclude_include'} = '';
     $self->{options}{'no_wrap'}         = '';
     $self->{options}{'verbatim'}        = '';
-    $self->{options}{'debug'}           = '';
     $self->{options}{'no-warn'}         = 0;    # TexInfo option to not warn about the state of the module
 
     %debug = ();
@@ -1648,8 +1647,8 @@ sub initialize {
         }
     }
 
-    if ( $options{'debug'} ) {
-        foreach ( $options{'debug'} ) {
+    if ( $self->{options}{'debug'} ) {
+        foreach ( $self->{options}{'debug'} ) {
             $debug{$_} = 1;
         }
     }

--- a/lib/Locale/Po4a/Text.pm
+++ b/lib/Locale/Po4a/Text.pm
@@ -221,7 +221,6 @@ sub initialize {
     $self->{options}{'control'}         = "";
     $self->{options}{'breaks'}          = 1;
     $self->{options}{'debianchangelog'} = 1;
-    $self->{options}{'debug'}           = 1;
     $self->{options}{'fortunes'}        = 1;
     $self->{options}{'markdown'}        = 1;
     $self->{options}{'yfm_keys'}        = '';

--- a/lib/Locale/Po4a/Text.pm
+++ b/lib/Locale/Po4a/Text.pm
@@ -231,7 +231,6 @@ sub initialize {
     $self->{options}{'nobullets'}       = 0;
     $self->{options}{'keyvalue'}        = 1;
     $self->{options}{'tabs'}            = 1;
-    $self->{options}{'verbose'}         = 1;
     $self->{options}{'neverwrap'}       = 1;
 
     foreach my $opt ( keys %options ) {

--- a/lib/Locale/Po4a/Text.pm
+++ b/lib/Locale/Po4a/Text.pm
@@ -784,10 +784,7 @@ sub parse_markdown {
             $paragraph .= "$nextline";
             ( $nextline, $nextref ) = $self->shiftline();
         }
-        my $t = $self->translate(
-            $paragraph, $self->{ref}, $type,
-            "wrap"  => 0
-        );
+        my $t = $self->translate( $paragraph, $self->{ref}, $type, "wrap" => 0 );
         $self->pushline($t);
         $self->pushline($nextline);
         $paragraph        = "";

--- a/lib/Locale/Po4a/TransTractor.pm
+++ b/lib/Locale/Po4a/TransTractor.pm
@@ -377,6 +377,7 @@ sub new {
     $self->{options}{'wrap-po'}            = '';
     $self->{options}{'wrapcol'}            = '';
     $self->{options}{'verbose'}            = delete $options{verbose};
+    $self->{options}{'debug'}              = delete $options{debug};
     my $context_module = delete $options{context_module};
 
     # let the plugin parse the options and such
@@ -404,8 +405,8 @@ sub new {
     if ( defined $self->{options}{verbose} ) {
         $self->{TT}{verbose} = $self->{options}{verbose};
     }
-    if ( defined $options{'debug'} ) {
-        $self->{TT}{debug} = $options{'debug'};
+    if ( defined $self->{options}{'debug'} ) {
+        $self->{TT}{debug} = $self->{options}{'debug'};
     }
     if ( defined $options{'wrapcol'} ) {
         if ( $options{'wrapcol'} < 0 ) {

--- a/lib/Locale/Po4a/TransTractor.pm
+++ b/lib/Locale/Po4a/TransTractor.pm
@@ -376,6 +376,7 @@ sub new {
     $self->{options}{'package-version'}    = '';
     $self->{options}{'wrap-po'}            = '';
     $self->{options}{'wrapcol'}            = '';
+    $self->{options}{'verbose'}            = delete $options{verbose};
     my $context_module = delete $options{context_module};
 
     # let the plugin parse the options and such
@@ -400,8 +401,8 @@ sub new {
     #  [0] is the line content, [1] is the reference $filename:$linenum
     $self->{TT}{doc_in}  = ();
     $self->{TT}{doc_out} = ();
-    if ( defined $options{'verbose'} ) {
-        $self->{TT}{verbose} = $options{'verbose'};
+    if ( defined $self->{options}{verbose} ) {
+        $self->{TT}{verbose} = $self->{options}{verbose};
     }
     if ( defined $options{'debug'} ) {
         $self->{TT}{debug} = $options{'debug'};

--- a/lib/Locale/Po4a/VimHelp.pm
+++ b/lib/Locale/Po4a/VimHelp.pm
@@ -29,12 +29,6 @@ use warnings;
 
 use parent qw(Locale::Po4a::TransTractor);
 
-sub initialize {
-    my ( $self, %options ) = @_;
-    $self->{debug} = $options{debug};
-    return;
-}
-
 sub parse {
     my $self = shift;
 

--- a/lib/Locale/Po4a/Wml.pm
+++ b/lib/Locale/Po4a/Wml.pm
@@ -73,7 +73,7 @@ sub initialize {
 
     $self->SUPER::initialize(%options);
 
-    print "Call treat_options\n" if $self->{options}{'debug'};
+    print "Call treat_options\n" if $self->debug;
     $self->treat_options;
 }
 
@@ -108,8 +108,7 @@ sub read {
     # Mask mp4h cruft
     while ( $file =~ s|^#(.*)$|<!--PO4ASHARPBEGIN$1PO4ASHARPEND-->|m ) {
         my $line = $1;
-        print STDERR "PROTECT HEADER: $line\n"
-          if $self->{options}{'debug'};
+        print STDERR "PROTECT HEADER: $line\n" if $self->debug;
 
         # If the wml tag has a title attribute, use a fake
         # <title> xml tag to enable the extraction

--- a/lib/Locale/Po4a/Xhtml.pm
+++ b/lib/Locale/Po4a/Xhtml.pm
@@ -223,7 +223,7 @@ sub initialize {
 
     $self->{options}{'optionalclosingtag'} = 1;
 
-    print "Call treat_options\n" if $self->{options}{'debug'};
+    print "Call treat_options\n" if $self->debug;
     $self->treat_options;
 
     if ( defined $self->{options}{'includessi'}

--- a/lib/Locale/Po4a/Xhtml.pm
+++ b/lib/Locale/Po4a/Xhtml.pm
@@ -99,7 +99,7 @@ use vars qw(@tag_types);
 *tag_types = \@Locale::Po4a::Xml::tag_types;
 
 use Locale::Po4a::Common qw(wrap_mod dgettext);
-use Carp qw(croak);
+use Carp                 qw(croak);
 
 sub tag_extract_SSI {
     my ( $self, $remove ) = ( shift, shift );

--- a/lib/Locale/Po4a/Xml.pm
+++ b/lib/Locale/Po4a/Xml.pm
@@ -637,7 +637,7 @@ sub initialize {
     # by this module or sub-module (unless specified in an option)
     $self->{nodefault} = ();
 
-    print "Call treat_options\n" if $self->{options}{'debug'};
+    print "Call treat_options\n" if $self->debug;
     $self->treat_options;
 
     #  Clear cache
@@ -1338,7 +1338,7 @@ sub treat_tag {
     my $line = &{ $tag_types[$type]->{f_translate} }( $self, @lines );
     print wrap_mod( "po4a::xml::treat_tag", "%s: type=%s <%s%s%s%s%s>",
         $lines[1], $type, $match1, $space1, $line, $space2, $match2 )
-      if $self->{options}{'debug'};
+      if $self->debug;
     $self->pushline( "<" . $match1 . $space1 . $line . $space2 . $match2 . ">" );
     return $eof;
 }
@@ -1463,7 +1463,7 @@ sub treat_attributes {
                         ),
                         $ref, $value,
                         $self->get_path . $name
-                    ) if $self->{options}{'debug'};
+                    ) if $self->debug;
                     $text .= $value;
                 }
                 $text .= $quot;
@@ -1603,7 +1603,7 @@ sub get_translate_options {
                     "%s: translation option='%s'.\n *** the original translation option is overridden here since parent path='%s' is untranslated,"
                 ),
                 $path, $options, $ppath
-            ) if $self->{options}{'debug'};
+            ) if $self->debug;
         }
     }
 
@@ -1616,14 +1616,14 @@ sub get_translate_options {
             "po4a::xml::get_translate_options",
             dgettext( "po4a", "%s: foldattributes setting ignored since '%s' is not inline tag" ),
             $path, $tag
-        ) if $self->{options}{'debug'};
+        ) if $self->debug;
     }
 
     $translate_options_cache{$path} = $options;
 
     #    print "option($path)=".$translate_options_cache{$path}." (new)\n";
 
-    #print wrap_mod("po4a::xml::get_translate_options", dgettext ("po4a", "%s: options: '%s'"), $path, $options) if $self->{options}{'debug'};
+    #print wrap_mod("po4a::xml::get_translate_options", dgettext ("po4a", "%s: options: '%s'"), $path, $options) if $self->debug;
     return $options;
 }
 
@@ -1694,7 +1694,7 @@ sub treat_content {
             # input stream and save its content to @comments for use by
             # translate_paragraph.
             print wrap_mod( "po4a::xml::treat_content", "%s: type='%s'", $paragraph[1], $type )
-              if $self->{options}{'debug'};
+              if $self->debug;
             ( $eof, @text ) = $self->extract_tag( $type, 1 );
 
             # Add "\0" to mark end of each separate comment
@@ -2029,7 +2029,7 @@ sub translate_paragraph {
                 "po4a::xml::translate_paragraph",
                 "%s: path='%s', translation option='%s'",
                 $paragraph[1], $self->get_path, $translate
-            ) if $self->{options}{'debug'};
+            ) if $self->debug;
             $self->pushline(
                 $self->found_string(
                     $para,
@@ -2048,7 +2048,7 @@ sub translate_paragraph {
                 "po4a::xml::translate_paragraph",
                 "%s: path='%s', translation option='%s' (no translation)",
                 $paragraph[1], $self->get_path, $translate
-            ) if $self->{options}{'debug'};
+            ) if $self->debug;
             $self->pushline($para);
         }
     }
@@ -2315,7 +2315,7 @@ sub treat_options {
     # -- XML tags in these may specify options: wWip
     # Extraction of XML content can be one of "inline", "break", "placeholder", or "customtag".
     # -- XML tags in these must not specify options
-    if ( $self->{options}{'debug'} ) {
+    if ( $self->debug ) {
         foreach my $tagtype (qw(translated untranslated)) {
             foreach my $tag ( sort keys %{ $self->{$tagtype} } ) {
                 print

--- a/lib/Locale/Po4a/Xml.pm
+++ b/lib/Locale/Po4a/Xml.pm
@@ -594,8 +594,7 @@ sub initialize {
     $self->{options}{'ontagerror'}             = "fail";
     $self->{options}{'cpp'}                    = 0;
 
-    $self->{options}{'verbose'} = '';
-    $self->{options}{'debug'}   = '';
+    $self->{options}{'debug'} = '';
 
     foreach my $opt ( keys %options ) {
         if ( $options{$opt} ) {

--- a/lib/Locale/Po4a/Xml.pm
+++ b/lib/Locale/Po4a/Xml.pm
@@ -594,8 +594,6 @@ sub initialize {
     $self->{options}{'ontagerror'}             = "fail";
     $self->{options}{'cpp'}                    = 0;
 
-    $self->{options}{'debug'} = '';
-
     foreach my $opt ( keys %options ) {
         if ( $options{$opt} ) {
             die wrap_mod( "po4a::xml::initialize", dgettext( "po4a", "Unknown option: %s" ), $opt )

--- a/lib/Locale/Po4a/Yaml.pm
+++ b/lib/Locale/Po4a/Yaml.pm
@@ -97,7 +97,6 @@ sub initialize {
     $self->{options}{'keys'}       = '';
     $self->{options}{'paths'}      = '';
     $self->{options}{'debug'}      = 0;
-    $self->{options}{'verbose'}    = 1;
     $self->{options}{'skip_array'} = 0;
 
     foreach my $opt ( keys %options ) {

--- a/lib/Locale/Po4a/Yaml.pm
+++ b/lib/Locale/Po4a/Yaml.pm
@@ -96,7 +96,6 @@ sub initialize {
 
     $self->{options}{'keys'}       = '';
     $self->{options}{'paths'}      = '';
-    $self->{options}{'debug'}      = 0;
     $self->{options}{'skip_array'} = 0;
 
     foreach my $opt ( keys %options ) {


### PR DESCRIPTION
This is a minor refactoring of `debug` and `verbose` options, allowing format modules to more easily ignore them when overriding the `initialize` subroutine.  Additionally the `debug` subroutine is utilized in some places instead of direct attribute accessings.
