### PR TITLE
Fix msginit compatibility with gettext >= 1.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,8 @@ General:
  * Support gettext msgctxt (GitHub's #627) [gemmaro]
    See Locale::Po4a::Po(3pm) for more details, and the example in the
    test suite: t/context.t for an usage in practice.
+ * Fix msginit compatibility with gettext >= 1.0 (GitHub's #636)
+   [philiptaron]
 
 AsciiDoc:
  * Fix line numbers and order when include macro is inside of lists

--- a/po4a
+++ b/po4a
@@ -1996,6 +1996,10 @@ if ( not $po4a_opts{"no-update"} ) {
                 }
 
                 my $read_pot_filename = find_input_file($pot_filename);
+                # Remove the output file if it exists (e.g. as an empty file),
+                # because gettext >= 1.0's msginit merges into existing files
+                # instead of overwriting, producing broken PO headers.
+                unlink $outfile if ( -e $outfile && -z $outfile );
                 my $cmd =
                     "msginit$Config{_exe} -i \"$read_pot_filename\" --locale $lang" . " "
                   . gettext_wrap_opts( $po4a_opts{"wrap-po"} )


### PR DESCRIPTION
Hi! I ran into the same breakage reported in #636 while building po4a with Nix against gettext 1.0. Here's a small fix.

## Background

The [gettext 1.0 release](https://savannah.gnu.org/news/?id=10853) changed `msginit`'s behavior when the output file already exists: instead of failing with an error, it now merges into the existing file like `msgmerge` would. That's a nice improvement for the normal translator workflow, but it trips up `po4a` because `po4a` sometimes passes an empty PO file as the output target. When `msginit` merges into that empty file, the result has stripped headers and corrupted UTF-8 content. This is exactly the symptoms in #636. It's detected with one of the unit tests, which is how I found it.

## This PR

Before calling `msginit`, remove the output file if it exists and is empty (`unlink $outfile if ( -e $outfile && -z $outfile )`). That way `msginit` always sees a fresh path and creates a proper PO file with correct headers, regardless of `gettext` version.

## Testing

I tested this using Nix and the Nixpkgs derivation for po4a, building against [gettext 1.0](https://github.com/NixOS/nixpkgs/pull/485233) and gettext 0.26. The two `t/cfg-single.t` failures from #636 (`single-podirectory-emptypot-emptypo` and `single-emptypo` with UTF-8 msgids) both pass with this patch applied.

## Appreciation

I note that the most recent release is dedicated to Simone Weil. Her writing on attention as the rarest form of generosity resonates with me and my intentions for contributing to the world.

Closes #636